### PR TITLE
Adopt paper's 6-level greedy priority (8.590% → 12.188%)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Solitaire simulator for finding the best strategy...
-# Current record is 8.590%.
+# Current record is 12.188%.
 
 ---
 
@@ -12,6 +12,15 @@
   - Play is the same as 1.0, but deck shuffling can be repeatable via the seed parameter.
 - 1.2
   - Play changed from {s2g, b2g, b2b, s2b} to {s2g, b2b, b2g, s2b} sequencing.  Winning percentage increased from 7.915% to 8.590%.
+- 1.3
+  - Adopted the 6-level greedy action priority from Bjarnason, Fern, Tadepalli, [*Lower Bounding Klondike Solitaire with Monte-Carlo Planning*, ICAPS 2009](https://ojs.aaai.org/index.php/ICAPS/article/view/13363) (pg. 3):
+    1. tableau → foundation that reveals a face-down card
+    2. any other move to a foundation
+    3. tableau → tableau that reveals a face-down card
+    4. deck → tableau
+    5. foundation → tableau (not implemented)
+    6. tableau → tableau that does not reveal
+  - After any move, re-evaluate from priority 1.  Winning percentage increased from 8.590% to 12.188% (three-card draw, 100k games, seed 1111).
 
 ## How To:
 - run `ant`

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Solitaire simulator for finding the best strategy...
-# Current record is 12.188%.
+# Current record is 12.154%.
 
 ---
 
@@ -20,7 +20,7 @@
     4. deck → tableau
     5. foundation → tableau (not implemented)
     6. tableau → tableau that does not reveal
-  - After any move, re-evaluate from priority 1.  Winning percentage increased from 8.590% to 12.188% (three-card draw, 100k games, seed 1111).
+  - After any move, re-evaluate from priority 1.  Winning percentage increased from 8.590% to 12.154% (three-card draw, 100k games, seed 1111).
 
 ## How To:
 - run `ant`

--- a/src/org/dacracot/Player.java
+++ b/src/org/dacracot/Player.java
@@ -21,29 +21,55 @@ public class Player {
 		//-------------------------------------------
 		int loops = 0;
 		int flops = 0;
-		// Play until there are no moves for three loops.
+		// Prioritized greedy action selection following Bjarnason, Fern,
+		// Tadepalli 2009 ("Lower Bounding Klondike Solitaire with
+		// Monte-Carlo Planning", ICAPS-09, pg. 3):
+		//   1. tableau -> foundation that reveals a face-down card
+		//   2. any other move to a foundation stack
+		//   3. tableau -> tableau that reveals a face-down card
+		//   4. deck -> tableau
+		//   5. foundation -> tableau (not implemented)
+		//   6. tableau -> tableau that does not reveal
+		// After each move, re-evaluate from priority 1.
 		while(flops < 3) {
-			// Play only one (or none) from stack to goal
-			if (fromStack.toGoal()) {
-				// Played a card
-				flops = 0;
+			boolean moved = true;
+			while(moved) {
+				moved = false;
+				if (fromBoard.toGoalReveal()) {
+					flops = 0;
+					moved = true;
+					game.showAll("b2g+  >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops));
+					continue;
+					}
+				if (fromBoard.toGoal()) {
+					flops = 0;
+					moved = true;
+					game.showAll("b2g   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops));
+					continue;
+					}
+				if (fromStack.toGoal()) {
+					flops = 0;
+					moved = true;
+					game.showAll("s2g   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops));
+					continue;
+					}
+				if (fromBoard.toBoardReveal()) {
+					moved = true;
+					game.showAll("b2b+  >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops));
+					continue;
+					}
+				if (fromStack.toBoard()) {
+					moved = true;
+					game.showAll("s2b   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops));
+					continue;
+					}
+				if (fromBoard.toBoardNoReveal()) {
+					moved = true;
+					game.showAll("b2b   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops));
+					continue;
+					}
 				}
-			game.showAll("s2g   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops));
-			// Play board to board until no more moves available
-			while(fromBoard.toBoard()) {
-				game.showAll("b2b   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops));
-				}
-			// Play only one (or none) from board to goal
-			if (fromBoard.toGoal()) {
-				// Played a card
-				flops = 0;
-				}
-			game.showAll("b2g   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops));
-			// Play stack to board until no more moves available
-			while(fromStack.toBoard()) {
-				game.showAll("s2b   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops));
-				}
-			// Turn over the stack
+			// Turn over the stack.
 			if (game.stack.flip()) {
 				flops++;
 				}

--- a/src/org/dacracot/move/FromBoard.java
+++ b/src/org/dacracot/move/FromBoard.java
@@ -41,6 +41,48 @@ public class FromBoard implements From {
 		}
 	//-----------------------------------------------
 	//
+	// Move a card from the board to the board, but only if the source's
+	// column has face-down cards (so that the move reveals a new card).
+	//
+	public boolean toBoardReveal() {
+		ArrayList<Card> bottomUpCards = game.board.getUpCardsFromBottom();
+		ArrayList<Card> topUpCards = game.board.getUpCardsFromTop();
+		for(Card bottomUpCard : bottomUpCards) {
+			for(Card topUpCard : topUpCards) {
+				if (!game.board.columnHasHidden(topUpCard)) continue;
+				if (game.board.playKingFromBoard(topUpCard)) {
+					return(true);
+					}
+				if (game.board.playCard(bottomUpCard,topUpCard)) {
+					return(true);
+					}
+				}
+			}
+		return(false);
+		}
+	//-----------------------------------------------
+	//
+	// Move a card from the board to the board, only when the source's
+	// column has no face-down cards (no reveal happens).
+	//
+	public boolean toBoardNoReveal() {
+		ArrayList<Card> bottomUpCards = game.board.getUpCardsFromBottom();
+		ArrayList<Card> topUpCards = game.board.getUpCardsFromTop();
+		for(Card bottomUpCard : bottomUpCards) {
+			for(Card topUpCard : topUpCards) {
+				if (game.board.columnHasHidden(topUpCard)) continue;
+				if (game.board.playKingFromBoard(topUpCard)) {
+					return(true);
+					}
+				if (game.board.playCard(bottomUpCard,topUpCard)) {
+					return(true);
+					}
+				}
+			}
+		return(false);
+		}
+	//-----------------------------------------------
+	//
 	// Move a card from the board to the goal.
 	//
 	@Override
@@ -59,6 +101,23 @@ public class FromBoard implements From {
 			// Play all playable cards, return true.
 			}
 		// Return false if no play as available.
+		return(played);
+		}
+	//-----------------------------------------------
+	//
+	// Move a card from the board to the goal, but only when removing
+	// the card would reveal a face-down card underneath it.
+	//
+	public boolean toGoalReveal() {
+		boolean played = false;
+		ArrayList<Card> bottomUpCards = game.board.getUpCardsFromBottom();
+		for(Card bottomUpCard : bottomUpCards) {
+			if (!game.board.removeCardWouldReveal(bottomUpCard)) continue;
+			if (game.goal.playCard(bottomUpCard)) {
+				game.board.removeCard(bottomUpCard);
+				played = true;
+				}
+			}
 		return(played);
 		}
 	//-----------------------------------------------

--- a/src/org/dacracot/move/FromBoard.java
+++ b/src/org/dacracot/move/FromBoard.java
@@ -49,12 +49,23 @@ public class FromBoard implements From {
 		ArrayList<Card> topUpCards = game.board.getUpCardsFromTop();
 		for(Card bottomUpCard : bottomUpCards) {
 			for(Card topUpCard : topUpCards) {
-				if (!game.board.columnHasHidden(topUpCard)) continue;
-				if (game.board.playKingFromBoard(topUpCard)) {
-					return(true);
+				if (topUpCard.getValue() == 13) {
+					// playKingFromBoard moves only the king; it reveals iff
+					// the king is the bottom-most face-up card (i.e. hidden
+					// card directly beneath it).
+					if (!game.board.removeCardWouldReveal(topUpCard)) continue;
+					if (game.board.playKingFromBoard(topUpCard)) {
+						return(true);
+						}
 					}
-				if (game.board.playCard(bottomUpCard,topUpCard)) {
-					return(true);
+				else {
+					// playCard moves the whole face-up run; it reveals iff
+					// the column has any hidden card (bottomsUp flips the
+					// new bottom after the run is stripped).
+					if (!game.board.columnHasHidden(topUpCard)) continue;
+					if (game.board.playCard(bottomUpCard,topUpCard)) {
+						return(true);
+						}
 					}
 				}
 			}
@@ -70,12 +81,17 @@ public class FromBoard implements From {
 		ArrayList<Card> topUpCards = game.board.getUpCardsFromTop();
 		for(Card bottomUpCard : bottomUpCards) {
 			for(Card topUpCard : topUpCards) {
-				if (game.board.columnHasHidden(topUpCard)) continue;
-				if (game.board.playKingFromBoard(topUpCard)) {
-					return(true);
+				if (topUpCard.getValue() == 13) {
+					if (game.board.removeCardWouldReveal(topUpCard)) continue;
+					if (game.board.playKingFromBoard(topUpCard)) {
+						return(true);
+						}
 					}
-				if (game.board.playCard(bottomUpCard,topUpCard)) {
-					return(true);
+				else {
+					if (game.board.columnHasHidden(topUpCard)) continue;
+					if (game.board.playCard(bottomUpCard,topUpCard)) {
+						return(true);
+						}
 					}
 				}
 			}
@@ -109,16 +125,15 @@ public class FromBoard implements From {
 	// the card would reveal a face-down card underneath it.
 	//
 	public boolean toGoalReveal() {
-		boolean played = false;
 		ArrayList<Card> bottomUpCards = game.board.getUpCardsFromBottom();
 		for(Card bottomUpCard : bottomUpCards) {
 			if (!game.board.removeCardWouldReveal(bottomUpCard)) continue;
 			if (game.goal.playCard(bottomUpCard)) {
 				game.board.removeCard(bottomUpCard);
-				played = true;
+				return(true);
 				}
 			}
-		return(played);
+		return(false);
 		}
 	//-----------------------------------------------
 	}

--- a/src/org/dacracot/table/Board.java
+++ b/src/org/dacracot/table/Board.java
@@ -139,6 +139,29 @@ public class Board {
 		return(false);
 		}
 	//-----------------------------------------------
+	public boolean columnHasHidden(Card c) {
+		for(int i=0; i<SEVEN; i++) {
+			if (columns.get(i).contains(c)) {
+				for (Card card : columns.get(i)) {
+					if (card.isHidden()) return(true);
+					}
+				return(false);
+				}
+			}
+		return(false);
+		}
+	//-----------------------------------------------
+	public boolean removeCardWouldReveal(Card c) {
+		for(int i=0; i<SEVEN; i++) {
+			ArrayList<Card> col = columns.get(i);
+			if (col.contains(c)) {
+				if (col.indexOf(c) != col.size()-1) return(false);
+				return (col.size() >= 2) && col.get(col.size()-2).isHidden();
+				}
+			}
+		return(false);
+		}
+	//-----------------------------------------------
 	public boolean playCard(Card destination, Card source) {
 		ArrayList<Card> destinationColumn = null;
 		ArrayList<Card> sourceColumn = null;


### PR DESCRIPTION
## Summary

Replaces the current `{s2g, b2b, b2g, s2b}` action order in `Player.run()` with the 6-level greedy action priority from **Bjarnason, Fern, Tadepalli, *[Lower Bounding Klondike Solitaire with Monte-Carlo Planning](https://ojs.aaai.org/index.php/ICAPS/article/view/13363)*, ICAPS 2009** (pg. 3):

1. tableau → foundation that reveals a face-down card
2. any other move to a foundation
3. tableau → tableau that reveals a face-down card
4. deck → tableau
5. foundation → tableau *(not implemented — `FromGoal.toBoard()` remains stubbed)*
6. tableau → tableau that does not reveal

After any move, the loop re-evaluates from priority 1.

## Results

`java -jar simulator.jar --three --attempts 100000 --seed 1111`

| | Win rate | Wall time |
|---|---|---|
| Before (v1.2) | 8.637% | 2:50 |
| After (v1.3)  | **12.154%** | 1:45 |

**Δ = +3.52pp absolute (~+41% relative)**, ~34σ on a binomial at N=100k. Paper reports 12.992% on 1M games.

## Changes

- `Board.java`: two new read-only predicates
  - `columnHasHidden(Card)` — does the source card's column still contain a face-down card?
  - `removeCardWouldReveal(Card)` — would removing this card expose a face-down card underneath?
- `FromBoard.java`: three new action methods
  - `toBoardReveal()` / `toBoardNoReveal()` — split by whether the move reveals a face-down card. Runs use `columnHasHidden`; kings use `removeCardWouldReveal` (since `playKingFromBoard` moves only the king, not the whole face-up run).
  - `toGoalReveal()` — `toGoal()` filtered by `removeCardWouldReveal`, returning after the first successful play so the outer loop re-evaluates from priority 1.
  - Existing `toBoard()` / `toGoal()` unchanged (still used by the `From` interface / `FromStack` / `FromGoal`)
- `Player.java`: priority-ordered loop with re-evaluation after every move; `flops` semantics unchanged (resets on any to-foundation play; increments on a full stack wrap-around with no to-foundation plays)
- `README.md`: new record, v1.3 entry, paper link

No new search machinery, no changes to move/card/deck semantics.

## Out of scope

- Priority 5 (foundation → tableau). `FromGoal.toBoard()` is stubbed in the current code and rarely matters in practice.
- Cycle avoidance. The paper mentions disqualifying actions that repeat states; not done here. The outer `flops < 3` termination still guarantees games end.
- UCT / HOP / Sparse UCT. The paper's main contribution, but a separate tier of work.

## Review feedback addressed

Second commit (`1f343b0`) addresses two [P2 comments from Greptile](https://github.com/dacracot/Klondike3-Simulator/pull/53#pullrequestreview-4133361498):
- **King-reveal predicate**: The original `toBoardReveal` used `columnHasHidden(src)` for all moves, which is correct for run moves (`playCard` moves the entire face-up cascade, exposing any hidden card via `bottomsUp`) but overapproximates for king moves (`playKingFromBoard` moves only the king, so it only reveals when the king is the bottom-most face-up card). Fixed by dispatching on `value == 13` and using `removeCardWouldReveal` for kings. Also mirrored the inverse guard in `toBoardNoReveal`, which otherwise would have dropped mid-run-king moves from both priority-3 and priority-6.
- **`toGoalReveal` return semantics**: Originally played all eligible cards in a single call. Changed to return after the first play so the outer loop re-scans priority 1, matching the paper's "re-evaluate after any move" semantics strictly.

Measured impact on win rate: 12.188% → 12.154% (seed 1111, 100k, three-card) — statistically indistinguishable (σ ≈ 0.10pp), but closer to the paper's stated behavior.

## Test plan

- [x] `java -jar simulator.jar --three --attempts 100000 --seed 1111` — 12.154% (vs. 8.637% on `main`)
- [x] `--debug` spot-check: a handful of wins look reasonable (no obvious move-order weirdness)
- [ ] 1M-game run for convergence to ≈12.9%  *(not run; happy to add if useful)*