### PR TITLE
quiet switch

### DIFF
--- a/src/org/dacracot/Global.java
+++ b/src/org/dacracot/Global.java
@@ -8,6 +8,7 @@ public class Global {
 	public static int tries = 10;
 	public static Random random = null;
 	public static boolean debug = false;
+	public static boolean quiet = false;
 	public static StringBuffer activeGame = new StringBuffer();
 	//-----------------------------------------------
 	}

--- a/src/org/dacracot/Solitaire.java
+++ b/src/org/dacracot/Solitaire.java
@@ -57,7 +57,7 @@ public class Solitaire {
 			Global.random = new Random(); // truly Random for no parameters
 			}
 		System.out.println("");
-		System.out.println("running: turn "+Global.cards+" cards and "+Global.tries+" attempts "+(Global.quiet?"quietly ":" ")+(Global.debug?"with":"without")+" debug "+(seeded?("with "+seed+" seed"):"without a seed"));
+		System.out.println("running: turn "+Global.cards+" cards and "+Global.tries+" attempts"+(Global.quiet?" quietly ":" ")+(Global.debug?"with":"without")+" debug "+(seeded?("with "+seed+" seed"):"without a seed"));
 		//-------------------------------------------
 		int winner = 0;
 		Instant start = Instant.now();

--- a/src/org/dacracot/Solitaire.java
+++ b/src/org/dacracot/Solitaire.java
@@ -40,19 +40,24 @@ public class Solitaire {
 				Global.random = new Random(); // truly Random
 				}
 			Global.debug = (params.indexOf("--debug") != -1);
+			Global.quiet = (params.indexOf("--quiet") != -1);
+			if (Global.quiet) {
+				Global.debug = false;
+				}
 			}
 		else{
-			System.out.println("usage: [--one|--three] [--attempts #] [--debug]  [--seed #]");
+			System.out.println("usage: [--one|--three] [--attempts #] [--debug|--quiet]  [--seed #]");
 			System.out.println("    --one: Turn only one card each play.");
 			System.out.println("    --three: Turn three cards each play.");
 			System.out.println("    --attempts: Number of games to attempt.");
 			System.out.println("    --debug: Verbose output about each game.");
+			System.out.println("    --quiet: Minimal output about each game.");
 			System.out.println("    --seed: Random seed for repeatable play.");
 			System.out.println("");
 			Global.random = new Random(); // truly Random for no parameters
 			}
 		System.out.println("");
-		System.out.println("running: turn "+Global.cards+" cards and "+Global.tries+" attempts "+(Global.debug?"with":"without")+" debug "+(seeded?("with "+seed+" seed"):"without a seed"));
+		System.out.println("running: turn "+Global.cards+" cards and "+Global.tries+" attempts "+(Global.quiet?"quietly ":" ")+(Global.debug?"with":"without")+" debug "+(seeded?("with "+seed+" seed"):"without a seed"));
 		//-------------------------------------------
 		int winner = 0;
 		Instant start = Instant.now();
@@ -61,12 +66,16 @@ public class Solitaire {
  			Player player = new Player(Global.cards);
  			if (player.run()) {
  				winner++;
- 				System.out.println("================== WINNER ==================");
- 				System.out.println(Global.activeGame);
- 				System.out.println("================== WINNER ==================");
+ 				if (!Global.quiet) {
+					System.out.println("================== WINNER ==================");
+					System.out.println(Global.activeGame);
+					System.out.println("================== WINNER ==================");
+					}
  				}
   			Global.activeGame.delete(0, Global.activeGame.length());
-			System.out.println("Game "+i+" of "+Global.tries);
+			if (!Global.quiet) {
+				System.out.println("Game "+i+" of "+Global.tries);
+				}
 			}
 		//-------------------------------------------
  		Instant end = Instant.now();


### PR DESCRIPTION
Added quiet mode.  Quiet trumps debug even if the debug switch is set.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `--quiet` flag that suppresses per-game output (winner banners and game-progress lines) while keeping the initial \"running\" banner and final summary stats. When `--quiet` is provided, `Global.debug` is forcefully set to `false`, honouring the stated \"quiet trumps debug\" semantics.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the only finding is a cosmetic double-space in one output line.

All P2 findings — no logic errors or security issues. The quiet-trumps-debug behaviour is implemented correctly, usage help is updated, and final summary output is preserved.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/org/dacracot/Global.java | Adds `quiet` static boolean field (defaulting to `false`) alongside the existing `debug` field — straightforward and correct. |
| src/org/dacracot/Solitaire.java | Parses `--quiet` flag, forces `debug=false` when quiet is set, suppresses per-game output in quiet mode. Minor double-space in the "running" banner line when quiet is off. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Parse CLI params] --> B{params empty?}
    B -- yes --> C[Print usage & run with defaults]
    B -- no --> D{--quiet present?}
    D -- yes --> E[Global.quiet = true\nGlobal.debug = false]
    D -- no --> F{--debug present?}
    F -- yes --> G[Global.debug = true]
    F -- no --> H[Global.debug = false]
    E --> I[Game loop]
    G --> I
    H --> I
    I --> J{player wins?}
    J -- yes --> K{quiet?}
    K -- no --> L[Print WINNER banner]
    K -- yes --> M[Skip banner]
    L --> N{quiet?}
    M --> N
    J -- no --> N
    N -- no --> O[Print 'Game i of tries']
    N -- yes --> P[Skip game line]
    O --> Q[Next iteration]
    P --> Q
    Q --> R[Print final success % & duration]
```

<sub>Reviews (1): Last reviewed commit: ["quiet switch"](https://github.com/dacracot/klondike3-simulator/commit/50caf597699b57fd01abc4184f44a55f822d988a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29711920)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->