### PR TITLE
Issue 60

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
     	- Without the debug switch, only errors will be output. With debug, all games are output.
 - run `java -jar simulator.jar --three --attempts 1000000 --seed 1111` to determine your success rate verses the current record.
 	- One million games takes about 20 minutes (without debug) on M2 MacBook Air.
-	- An even better measurement is a continuous run of 24 hours that shows the percentage, average percentage, standard deviation, maximin, and minimum.
+	- An even better measurement is a continuous run of 24 hours that shows the percentage, average percentage, standard deviation, maximun, and minimum.
 		- run `java -jar simulator.jar --quiet --continuous --seed 1111`
 
 ## Legend

--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@
     - Write standard error to debug.err.
     	- Without the debug switch, only errors will be output. With debug, all games are output.
 - run `java -jar simulator.jar --three --attempts 1000000 --seed 1111` to determine your success rate verses the current record.
-	- One million games takes less than an hour (without debug) on M2 MacBook Air.
+	- One million games takes about 20 minutes (without debug) on M2 MacBook Air.
+	- An even better measurement is a continuous run of 24 hours that shows the percentage, average percentage, standard deviation, maximin, and minimum.
+		- run `java -jar simulator.jar --quiet --continuous --seed 1111`
 
 ## Legend
 - |•A♦︎•|: Ace of Diamonds face down.

--- a/src/org/dacracot/Global.java
+++ b/src/org/dacracot/Global.java
@@ -15,9 +15,9 @@ public class Global {
 	public static boolean quiet = false;
 	public static StringBuffer activeGame = new StringBuffer();
 	// statistics
-	public static float valueSum = 0;
-	public static float varianceSum = 0;
-	public static float count = 0;
+	public static double valueSum = 0;
+	public static double varianceSum = 0;
+	public static int count = 0;
 	public static double valueHigh = 0.0;
 	public static double valueLow = 100.0;
 	public static int reportInterval = 1000000;

--- a/src/org/dacracot/Global.java
+++ b/src/org/dacracot/Global.java
@@ -19,6 +19,7 @@ public class Global {
 	public static float varianceSum = 0;
 	public static double valueHigh = 0.0;
 	public static double valueLow = 100.0;
+	public static int reportInterval = 10000;
 	//-----------------------------------------------
 	}
 //---------------------------------------------------

--- a/src/org/dacracot/Global.java
+++ b/src/org/dacracot/Global.java
@@ -17,6 +17,8 @@ public class Global {
 	// statistics
 	public static float valueSum = 0;
 	public static float varianceSum = 0;
+	public static double valueHigh = 0.0;
+	public static double valueLow = 100.0;
 	//-----------------------------------------------
 	}
 //---------------------------------------------------

--- a/src/org/dacracot/Global.java
+++ b/src/org/dacracot/Global.java
@@ -17,9 +17,11 @@ public class Global {
 	// statistics
 	public static float valueSum = 0;
 	public static float varianceSum = 0;
+	public static float count = 0;
 	public static double valueHigh = 0.0;
 	public static double valueLow = 100.0;
-	public static int reportInterval = 100000;
+	public static int reportInterval = 1000000;
+	public static int waitForSteadyState = reportInterval-100;
 	//-----------------------------------------------
 	}
 //---------------------------------------------------

--- a/src/org/dacracot/Global.java
+++ b/src/org/dacracot/Global.java
@@ -19,7 +19,7 @@ public class Global {
 	public static float varianceSum = 0;
 	public static double valueHigh = 0.0;
 	public static double valueLow = 100.0;
-	public static int reportInterval = 1000000;
+	public static int reportInterval = 100000;
 	//-----------------------------------------------
 	}
 //---------------------------------------------------

--- a/src/org/dacracot/Global.java
+++ b/src/org/dacracot/Global.java
@@ -14,6 +14,9 @@ public class Global {
 	public static boolean debug = false;
 	public static boolean quiet = false;
 	public static StringBuffer activeGame = new StringBuffer();
+	// statistics
+	public static float valueSum = 0;
+	public static float varianceSum = 0;
 	//-----------------------------------------------
 	}
 //---------------------------------------------------

--- a/src/org/dacracot/Global.java
+++ b/src/org/dacracot/Global.java
@@ -19,7 +19,7 @@ public class Global {
 	public static float varianceSum = 0;
 	public static double valueHigh = 0.0;
 	public static double valueLow = 100.0;
-	public static int reportInterval = 10000;
+	public static int reportInterval = 1000000;
 	//-----------------------------------------------
 	}
 //---------------------------------------------------

--- a/src/org/dacracot/Solitaire.java
+++ b/src/org/dacracot/Solitaire.java
@@ -106,7 +106,7 @@ public class Solitaire {
 				}
 			Global.tried++;
 			stats.setValue((((1.0*Global.winner)/Global.tried)*100));
-			if ((Global.tried % 100000) == 0) {
+			if ((Global.tried % Global.reportInterval) == 0) {
 				Duration between = Duration.between(Global.start, Instant.now());
 				System.out.println(stats.show());
 				}

--- a/src/org/dacracot/Solitaire.java
+++ b/src/org/dacracot/Solitaire.java
@@ -105,7 +105,7 @@ public class Solitaire {
 				System.out.println("Game "+Global.tried+((Global.tries==Integer.MAX_VALUE)?" until killed":" of "+Global.tries));
 				}
 			Global.tried++;
-			stats.setValue(stats.getPercentage());
+			stats.setValue();
 			if ((Global.tried % Global.reportInterval) == 0) {
 				Duration between = Duration.between(Global.start, Instant.now());
 				System.out.println(stats.show());

--- a/src/org/dacracot/Solitaire.java
+++ b/src/org/dacracot/Solitaire.java
@@ -106,16 +106,9 @@ public class Solitaire {
 				}
 			Global.tried++;
 			stats.setValue((((1.0*Global.winner)/Global.tried)*100));
-			if ((Global.tried % 1000000) == 0) {
+			if ((Global.tried % 100000) == 0) {
 				Duration between = Duration.between(Global.start, Instant.now());
-				System.out.println(
-					"progress: won "+Global.winner+
-					" of "+Global.tried+
-					" for "+String.format("%3.5f",(((1.0*Global.winner)/Global.tried)*100))+"%,"+
-					" with a standard deviation of "+String.format("%3.7f",stats.getStdDev())+
-					" across the mean of "+String.format("%3.5f",stats.getMean())+"%"+
-					" after a duration of "+String.format("%dD, %02d:%02d:%02d",between.toDays(),between.toHoursPart(),between.toMinutesPart(),between.toSecondsPart())
-					);
+				System.out.println(stats.show());
 				}
 			}
 		//-------------------------------------------

--- a/src/org/dacracot/Solitaire.java
+++ b/src/org/dacracot/Solitaire.java
@@ -88,7 +88,6 @@ public class Solitaire {
 			(seeded?("with "+seed+" seed"):"without a seed")
 			);
 		System.out.println("");
-System.err.println("percent\tcount\tsum\tmean\tmin\tmax");
 		//-------------------------------------------
 		Global.tried=0;
 		while(Global.tried<Global.tries){

--- a/src/org/dacracot/Solitaire.java
+++ b/src/org/dacracot/Solitaire.java
@@ -4,6 +4,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Random;
 import java.util.Scanner;
+import org.dacracot.util.Statistics;
 //---------------------------------------------------
 public class Solitaire {
 	//-----------------------------------------------
@@ -86,6 +87,7 @@ public class Solitaire {
 			(seeded?("with "+seed+" seed"):"without a seed")
 			);
 		//-------------------------------------------
+		Statistics stats = new Statistics();
 		Global.tried=0;
 		while(Global.tried<Global.tries){
  			Player player = new Player(Global.cards);
@@ -102,8 +104,9 @@ public class Solitaire {
 				System.out.println("Game "+Global.tried+((Global.tries==Integer.MAX_VALUE)?" until killed":" of "+Global.tries));
 				}
 			Global.tried++;
+			stats.setValue((((1.0*Global.winner)/Global.tried)*100));
 			if ((Global.tried % 1000000) == 0) {
-				System.out.println("progress: won "+Global.winner+" of "+Global.tried+" for "+String.format("%3.5f",(((1.0*Global.winner)/Global.tried)*100))+"%");
+				System.out.println("progress: won "+Global.winner+" of "+Global.tried+" for "+String.format("%3.5f",(((1.0*Global.winner)/Global.tried)*100))+"%, with a standard deviation of "+String.format("%3.7f",stats.getStdDev())+" across the mean of "+String.format("%3.5f",stats.getMean())+"%");
 				}
 			}
 		//-------------------------------------------

--- a/src/org/dacracot/Solitaire.java
+++ b/src/org/dacracot/Solitaire.java
@@ -11,11 +11,12 @@ public class Solitaire {
 	public Solitaire(){}
 	//-----------------------------------------------
 	public static void main(String[] args){
+		Statistics stats = new Statistics();
 		//-------------------------------------------
 		Runtime.getRuntime().addShutdownHook(new Thread(() -> {
 			Instant end = Instant.now();
 			System.out.println("");
-			System.out.println("success: won "+Global.winner+" of "+Global.tried+" for "+String.format("%3.5f",(((1.0*Global.winner)/Global.tried)*100))+"%");
+			System.out.println("success: won "+Global.winner+" of "+Global.tried+" for "+String.format("%3.5f",stats.getPercentage())+"%");
 			Duration between = Duration.between(Global.start, end);
 			System.out.println("");
 			System.out.format(
@@ -88,7 +89,6 @@ public class Solitaire {
 			);
 		System.out.println("");
 		//-------------------------------------------
-		Statistics stats = new Statistics();
 		Global.tried=0;
 		while(Global.tried<Global.tries){
  			Player player = new Player(Global.cards);
@@ -105,7 +105,7 @@ public class Solitaire {
 				System.out.println("Game "+Global.tried+((Global.tries==Integer.MAX_VALUE)?" until killed":" of "+Global.tries));
 				}
 			Global.tried++;
-			stats.setValue((((1.0*Global.winner)/Global.tried)*100));
+			stats.setValue(stats.getPercentage());
 			if ((Global.tried % Global.reportInterval) == 0) {
 				Duration between = Duration.between(Global.start, Instant.now());
 				System.out.println(stats.show());

--- a/src/org/dacracot/Solitaire.java
+++ b/src/org/dacracot/Solitaire.java
@@ -106,7 +106,15 @@ public class Solitaire {
 			Global.tried++;
 			stats.setValue((((1.0*Global.winner)/Global.tried)*100));
 			if ((Global.tried % 1000000) == 0) {
-				System.out.println("progress: won "+Global.winner+" of "+Global.tried+" for "+String.format("%3.5f",(((1.0*Global.winner)/Global.tried)*100))+"%, with a standard deviation of "+String.format("%3.7f",stats.getStdDev())+" across the mean of "+String.format("%3.5f",stats.getMean())+"%");
+				Duration between = Duration.between(Global.start, Instant.now());
+				System.out.println(
+					"progress: won "+Global.winner+
+					" of "+Global.tried+
+					" for "+String.format("%3.5f",(((1.0*Global.winner)/Global.tried)*100))+"%,"+
+					" with a standard deviation of "+String.format("%3.7f",stats.getStdDev())+
+					" across the mean of "+String.format("%3.5f",stats.getMean())+"%"+
+					" after a duration of "+String.format(" %dD, %02d:%02d:%02d",between.toDays(),between.toHoursPart(),between.toMinutesPart(),between.toSecondsPart())
+					);
 				}
 			}
 		//-------------------------------------------

--- a/src/org/dacracot/Solitaire.java
+++ b/src/org/dacracot/Solitaire.java
@@ -88,6 +88,7 @@ public class Solitaire {
 			(seeded?("with "+seed+" seed"):"without a seed")
 			);
 		System.out.println("");
+System.err.println("percent\tcount\tsum\tmean\tmin\tmax");
 		//-------------------------------------------
 		Global.tried=0;
 		while(Global.tried<Global.tries){

--- a/src/org/dacracot/Solitaire.java
+++ b/src/org/dacracot/Solitaire.java
@@ -101,15 +101,10 @@ public class Solitaire {
 					}
  				}
   			Global.activeGame.delete(0, Global.activeGame.length());
-			if (!Global.quiet) {
-				System.out.println("Game "+Global.tried+((Global.tries==Integer.MAX_VALUE)?" until killed":" of "+Global.tries));
-				}
+			if (!Global.quiet) System.out.println("Game "+Global.tried+((Global.tries==Integer.MAX_VALUE)?" until killed":" of "+Global.tries));
 			Global.tried++;
-			stats.setValue();
-			if ((Global.tried % Global.reportInterval) == 0) {
-				Duration between = Duration.between(Global.start, Instant.now());
-				System.out.println(stats.show());
-				}
+			if (Global.tried >= Global.waitForSteadyState) stats.setValue();
+			if ((Global.tried % Global.reportInterval) == 0) System.out.println(stats.show());
 			}
 		//-------------------------------------------
 		}

--- a/src/org/dacracot/Solitaire.java
+++ b/src/org/dacracot/Solitaire.java
@@ -86,6 +86,7 @@ public class Solitaire {
 			(Global.debug?"with":"without")+" debug "+
 			(seeded?("with "+seed+" seed"):"without a seed")
 			);
+		System.out.println("");
 		//-------------------------------------------
 		Statistics stats = new Statistics();
 		Global.tried=0;
@@ -113,7 +114,7 @@ public class Solitaire {
 					" for "+String.format("%3.5f",(((1.0*Global.winner)/Global.tried)*100))+"%,"+
 					" with a standard deviation of "+String.format("%3.7f",stats.getStdDev())+
 					" across the mean of "+String.format("%3.5f",stats.getMean())+"%"+
-					" after a duration of "+String.format(" %dD, %02d:%02d:%02d",between.toDays(),between.toHoursPart(),between.toMinutesPart(),between.toSecondsPart())
+					" after a duration of "+String.format("%dD, %02d:%02d:%02d",between.toDays(),between.toHoursPart(),between.toMinutesPart(),between.toSecondsPart())
 					);
 				}
 			}

--- a/src/org/dacracot/util/Statistics.java
+++ b/src/org/dacracot/util/Statistics.java
@@ -1,11 +1,15 @@
 package org.dacracot.util;
 //---------------------------------------------------
+import java.time.Duration;
+import java.time.Instant;
 import org.dacracot.Global;
 //---------------------------------------------------
 public class Statistics {
 	//-----------------------------------------------
 	public void setValue(double value) {
 		Global.valueSum+= value;
+		if (value > Global.valueHigh) Global.valueHigh = value;
+		if (value < Global.valueLow) Global.valueLow = value;
 		Global.varianceSum+= Math.pow((value - getMean()),2);
 		}
 	//-----------------------------------------------
@@ -15,6 +19,20 @@ public class Statistics {
 	//-----------------------------------------------
 	public double getStdDev() {
 		return(Math.sqrt(Global.varianceSum/Global.tried));
+		}
+	//-----------------------------------------------
+	public String show() {
+		Duration between = Duration.between(Global.start, Instant.now());
+		return(String.format(
+			"stats: won "+Global.winner+
+			" of "+Global.tried+
+			" for "+String.format("%3.5f",(((1.0*Global.winner)/Global.tried)*100))+"%,"+
+			" with a standard deviation of "+String.format("%3.7f",getStdDev())+
+			" across the mean of "+String.format("%3.5f",getMean())+"%"+
+			" with max of "+String.format("%3.5f",Global.valueHigh)+"%"+
+			" with min of "+String.format("%3.5f",Global.valueLow)+"%"+
+			" after a duration of "+String.format("%dD, %02d:%02d:%02d",between.toDays(),between.toHoursPart(),between.toMinutesPart(),between.toSecondsPart())
+			));
 		}
 	//-----------------------------------------------
 }

--- a/src/org/dacracot/util/Statistics.java
+++ b/src/org/dacracot/util/Statistics.java
@@ -1,0 +1,21 @@
+package org.dacracot.util;
+//---------------------------------------------------
+import org.dacracot.Global;
+//---------------------------------------------------
+public class Statistics {
+	//-----------------------------------------------
+	public void setValue(double value) {
+		Global.valueSum+= value;
+		Global.varianceSum+= Math.pow(value - getMean(), 2);
+		}
+	//-----------------------------------------------
+	public double getMean() {
+		return(Global.valueSum/Global.tried);
+		}
+	//-----------------------------------------------
+	public double getStdDev() {
+		return(Math.sqrt(Global.varianceSum/Global.tried));
+		}
+	//-----------------------------------------------
+}
+//-----------------------------------------------

--- a/src/org/dacracot/util/Statistics.java
+++ b/src/org/dacracot/util/Statistics.java
@@ -13,8 +13,6 @@ public class Statistics {
 		Global.varianceSum+= Math.pow((percent - getMean()),2);
 		if (percent > Global.valueHigh) Global.valueHigh = percent;
 		if (percent < Global.valueLow) Global.valueLow = percent;
-// System.out.println(show());
-// System.out.println("count: "+Global.count);
 		}
 	//-----------------------------------------------
 	public double getMean() {

--- a/src/org/dacracot/util/Statistics.java
+++ b/src/org/dacracot/util/Statistics.java
@@ -8,8 +8,10 @@ public class Statistics {
 	//-----------------------------------------------
 	public void setValue(double value) {
 		Global.valueSum+= value;
-		if (value > Global.valueHigh) Global.valueHigh = value;
-		if (value < Global.valueLow) Global.valueLow = value;
+		if (Global.tried > (Global.reportInterval-1)) {
+			if (value > Global.valueHigh) Global.valueHigh = value;
+			if (value < Global.valueLow) Global.valueLow = value;
+			}
 		Global.varianceSum+= Math.pow((value - getMean()),2);
 		}
 	//-----------------------------------------------
@@ -23,7 +25,7 @@ public class Statistics {
 	//-----------------------------------------------
 	public String show() {
 		Duration between = Duration.between(Global.start, Instant.now());
-		return(String.format(
+		return(
 			"stats: won "+Global.winner+
 			" of "+Global.tried+
 			" for "+String.format("%3.5f",(((1.0*Global.winner)/Global.tried)*100))+"%,"+
@@ -32,7 +34,7 @@ public class Statistics {
 			" with max of "+String.format("%3.5f",Global.valueHigh)+"%"+
 			" with min of "+String.format("%3.5f",Global.valueLow)+"%"+
 			" after a duration of "+String.format("%dD, %02d:%02d:%02d",between.toDays(),between.toHoursPart(),between.toMinutesPart(),between.toSecondsPart())
-			));
+			);
 		}
 	//-----------------------------------------------
 }

--- a/src/org/dacracot/util/Statistics.java
+++ b/src/org/dacracot/util/Statistics.java
@@ -8,20 +8,21 @@ public class Statistics {
 	//-----------------------------------------------
 	public void setValue() {
 		double percent = getPercentage();
+		Global.count++;
 		Global.valueSum+= percent;
-		if (Global.tried >= (Global.reportInterval-1)) {
-			if (percent > Global.valueHigh) Global.valueHigh = percent;
-			if (percent < Global.valueLow) Global.valueLow = percent;
-			}
 		Global.varianceSum+= Math.pow((percent - getMean()),2);
+		if (percent > Global.valueHigh) Global.valueHigh = percent;
+		if (percent < Global.valueLow) Global.valueLow = percent;
+// System.out.println(show());
+// System.out.println("count: "+Global.count);
 		}
 	//-----------------------------------------------
 	public double getMean() {
-		return(Global.valueSum/Global.tried);
+		return(Global.valueSum/Global.count);
 		}
 	//-----------------------------------------------
 	public double getStdDev() {
-		return(Math.sqrt(Global.varianceSum/Global.tried));
+		return(Math.sqrt(Global.varianceSum/Global.count));
 		}
 	//-----------------------------------------------
 	public double getPercentage() {

--- a/src/org/dacracot/util/Statistics.java
+++ b/src/org/dacracot/util/Statistics.java
@@ -8,9 +8,11 @@ public class Statistics {
 	//-----------------------------------------------
 	public void setValue() {
 		double percent = getPercentage();
+		double oldMean = getMean();
 		Global.count++;
 		Global.valueSum+= percent;
-		Global.varianceSum+= Math.pow((percent - getMean()),2);
+		double newMean = getMean();
+		Global.varianceSum+= (percent - oldMean) * (percent - newMean);
 		if (percent > Global.valueHigh) Global.valueHigh = percent;
 		if (percent < Global.valueLow) Global.valueLow = percent;
 		}
@@ -42,4 +44,4 @@ public class Statistics {
 		}
 	//-----------------------------------------------
 }
-//-----------------------------------------------
+//---------------------------------------------------

--- a/src/org/dacracot/util/Statistics.java
+++ b/src/org/dacracot/util/Statistics.java
@@ -6,11 +6,12 @@ import org.dacracot.Global;
 //---------------------------------------------------
 public class Statistics {
 	//-----------------------------------------------
-	public void setValue(double value) {
-		Global.valueSum+= value;
-		if (Global.tried > (Global.reportInterval-1)) {
-			if (value > Global.valueHigh) Global.valueHigh = value;
-			if (value < Global.valueLow) Global.valueLow = value;
+	public void setValue() {
+		double percent = getPercentage();
+		Global.valueSum+= percent;
+		if (Global.tried >= (Global.reportInterval-1)) {
+			if (percent > Global.valueHigh) Global.valueHigh = percent;
+			if (percent < Global.valueLow) Global.valueLow = percent;
 			}
 		Global.varianceSum+= Math.pow((value - getMean()),2);
 		}
@@ -23,12 +24,16 @@ public class Statistics {
 		return(Math.sqrt(Global.varianceSum/Global.tried));
 		}
 	//-----------------------------------------------
+	public double getPercentage() {
+		return(((1.0*Global.winner)/Global.tried)*100);
+		}
+	//-----------------------------------------------
 	public String show() {
 		Duration between = Duration.between(Global.start, Instant.now());
 		return(
 			"stats: won "+Global.winner+
 			" of "+Global.tried+
-			" for "+String.format("%3.5f",(((1.0*Global.winner)/Global.tried)*100))+"%,"+
+			" for "+String.format("%3.5f",getPercentage())+"%,"+
 			" with a standard deviation of "+String.format("%3.7f",getStdDev())+
 			" across the mean of "+String.format("%3.5f",getMean())+"%"+
 			" with max of "+String.format("%3.5f",Global.valueHigh)+"%"+

--- a/src/org/dacracot/util/Statistics.java
+++ b/src/org/dacracot/util/Statistics.java
@@ -13,7 +13,7 @@ public class Statistics {
 			if (percent > Global.valueHigh) Global.valueHigh = percent;
 			if (percent < Global.valueLow) Global.valueLow = percent;
 			}
-		Global.varianceSum+= Math.pow((value - getMean()),2);
+		Global.varianceSum+= Math.pow((percent - getMean()),2);
 		}
 	//-----------------------------------------------
 	public double getMean() {

--- a/src/org/dacracot/util/Statistics.java
+++ b/src/org/dacracot/util/Statistics.java
@@ -6,7 +6,7 @@ public class Statistics {
 	//-----------------------------------------------
 	public void setValue(double value) {
 		Global.valueSum+= value;
-		Global.varianceSum+= Math.pow(value - getMean(), 2);
+		Global.varianceSum+= Math.pow((value - getMean()),2);
 		}
 	//-----------------------------------------------
 	public double getMean() {

--- a/src/org/dacracot/util/Statistics.java
+++ b/src/org/dacracot/util/Statistics.java
@@ -8,11 +8,9 @@ public class Statistics {
 	//-----------------------------------------------
 	public void setValue() {
 		double percent = getPercentage();
-		double oldMean = getMean();
 		Global.count++;
 		Global.valueSum+= percent;
-		double newMean = getMean();
-		Global.varianceSum+= (percent - oldMean) * (percent - newMean);
+		Global.varianceSum+= Math.pow((percent - getMean()),2);
 		if (percent > Global.valueHigh) Global.valueHigh = percent;
 		if (percent < Global.valueLow) Global.valueLow = percent;
 		}
@@ -36,7 +34,7 @@ public class Statistics {
 			" of "+Global.tried+
 			" for "+String.format("%3.5f",getPercentage())+"%,"+
 			" with a standard deviation of "+String.format("%3.7f",getStdDev())+
-			" across the mean of "+String.format("%3.5f",getMean())+"%"+
+			" from the mean of "+String.format("%3.5f",getMean())+"%"+
 			" with max of "+String.format("%3.5f",Global.valueHigh)+"%"+
 			" with min of "+String.format("%3.5f",Global.valueLow)+"%"+
 			" after a duration of "+String.format("%dD, %02d:%02d:%02d",between.toDays(),between.toHoursPart(),between.toMinutesPart(),between.toSecondsPart())


### PR DESCRIPTION
Better statistics

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a `Statistics` class to track running win-percentage metrics (mean, standard deviation, max, min) sampled after a steady-state warm-up, and wires it into the main game loop for periodic reporting and shutdown output.

- **`Statistics.java`**: New utility that accumulates sample win-percentages using an incremental algorithm; the variance calculation has a correctness issue that causes `getStdDev()` to underreport the true spread.
- **`Global.java`**: Adds static fields for statistics state.
- **`Solitaire.java`**: Calls `stats.setValue()` each game after the warm-up threshold and prints a stats snapshot at every `reportInterval` games.

<h3>Confidence Score: 3/5</h3>

The new Statistics class produces an incorrect standard deviation; the reported stddev will be understated, making the better statistics feature misleading in practice.

The variance formula computes each sample deviation against the already-updated running mean that includes the current sample, so the first sample always contributes zero deviation and subsequent ones are pulled toward the running mean, resulting in a systematically low stddev.

src/org/dacracot/util/Statistics.java — the setValue() method needs the variance accumulation fixed before the statistics output can be trusted.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/org/dacracot/util/Statistics.java | New Statistics class; variance accumulation uses the post-update running mean rather than Welford's algorithm, producing an understated standard deviation. |
| src/org/dacracot/Global.java | Adds global statistics fields; straightforward additions with no issues. |
| src/org/dacracot/Solitaire.java | Integrates Statistics, calls setValue() after steady-state threshold, prints stats at each report interval; logic is correct. |
| README.md | Updated timing estimate and added continuous-run usage example; contains a "maximin" typo that should be "maximum". |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Main as Solitaire.main
    participant Player
    participant Stats as Statistics
    participant Global

    Main->>Player: run()
    Player-->>Main: win/loss result
    Main->>Global: tried++, winner++

    alt "tried >= waitForSteadyState"
        Main->>Stats: setValue()
        Stats->>Global: getPercentage()
        Stats->>Global: "count++, valueSum+=percent"
        Stats->>Stats: getMean() updated
        Stats->>Global: "varianceSum += deviation squared"
    end

    alt "tried % reportInterval == 0"
        Main->>Stats: show()
        Stats-->>Main: formatted stats string
    end

    Note over Main: On JVM shutdown
    Main->>Stats: getPercentage()
    Stats-->>Main: current win %
```

<sub>Reviews (1): Last reviewed commit: ["never enough README"](https://github.com/dacracot/klondike3-simulator/commit/107eca80bf7fea49072e19f6b497969b9ad88754) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32453807)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->