### PR TITLE
Version 1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
     	- Without the debug switch, only errors will be output. With debug, all games are output.
 - run `java -jar simulator.jar --three --attempts 1000000 --seed 1111` to determine your success rate verses the current record.
 	- One million games takes about 20 minutes (without debug) on M2 MacBook Air.
-	- An even better measurement is a continuous run of 24 hours that shows the percentage, average percentage, standard deviation, maximin, and minimum.
+	- An even better measurement is a continuous run of 24 hours that shows the percentage, average percentage, standard deviation, maximun, and minimum.
 		- run `java -jar simulator.jar --quiet --continuous --seed 1111`
 
 ## Legend

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
     	- Without the debug switch, only errors will be output. With debug, all games are output.
 - run `java -jar simulator.jar --three --attempts 1000000 --seed 1111` to determine your success rate verses the current record.
 	- One million games takes about 20 minutes (without debug) on M2 MacBook Air.
-	- An even better measurement is a continuous run of 24 hours that shows the percentage, average percentage, standard deviation, maximun, and minimum.
+	- An even better measurement is a continuous run of 24 hours that shows the percentage, average percentage, standard deviation, maximum, and minimum.
 		- run `java -jar simulator.jar --quiet --continuous --seed 1111`
 
 ## Legend

--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@
     - Write standard error to debug.err.
     	- Without the debug switch, only errors will be output. With debug, all games are output.
 - run `java -jar simulator.jar --three --attempts 1000000 --seed 1111` to determine your success rate verses the current record.
-	- One million games takes less than an hour (without debug) on M2 MacBook Air.
+	- One million games takes about 20 minutes (without debug) on M2 MacBook Air.
+	- An even better measurement is a continuous run of 24 hours that shows the percentage, average percentage, standard deviation, maximin, and minimum.
+		- run `java -jar simulator.jar --quiet --continuous --seed 1111`
 
 ## Legend
 - |•A♦︎•|: Ace of Diamonds face down.

--- a/src/org/dacracot/Global.java
+++ b/src/org/dacracot/Global.java
@@ -15,9 +15,9 @@ public class Global {
 	public static boolean quiet = false;
 	public static StringBuffer activeGame = new StringBuffer();
 	// statistics
-	public static float valueSum = 0;
-	public static float varianceSum = 0;
-	public static float count = 0;
+	public static double valueSum = 0;
+	public static double varianceSum = 0;
+	public static int count = 0;
 	public static double valueHigh = 0.0;
 	public static double valueLow = 100.0;
 	public static int reportInterval = 1000000;

--- a/src/org/dacracot/Global.java
+++ b/src/org/dacracot/Global.java
@@ -19,6 +19,7 @@ public class Global {
 	public static float varianceSum = 0;
 	public static double valueHigh = 0.0;
 	public static double valueLow = 100.0;
+	public static int reportInterval = 10000;
 	//-----------------------------------------------
 	}
 //---------------------------------------------------

--- a/src/org/dacracot/Global.java
+++ b/src/org/dacracot/Global.java
@@ -17,6 +17,8 @@ public class Global {
 	// statistics
 	public static float valueSum = 0;
 	public static float varianceSum = 0;
+	public static double valueHigh = 0.0;
+	public static double valueLow = 100.0;
 	//-----------------------------------------------
 	}
 //---------------------------------------------------

--- a/src/org/dacracot/Global.java
+++ b/src/org/dacracot/Global.java
@@ -17,9 +17,11 @@ public class Global {
 	// statistics
 	public static float valueSum = 0;
 	public static float varianceSum = 0;
+	public static float count = 0;
 	public static double valueHigh = 0.0;
 	public static double valueLow = 100.0;
-	public static int reportInterval = 100000;
+	public static int reportInterval = 1000000;
+	public static int waitForSteadyState = reportInterval-100;
 	//-----------------------------------------------
 	}
 //---------------------------------------------------

--- a/src/org/dacracot/Global.java
+++ b/src/org/dacracot/Global.java
@@ -19,7 +19,7 @@ public class Global {
 	public static float varianceSum = 0;
 	public static double valueHigh = 0.0;
 	public static double valueLow = 100.0;
-	public static int reportInterval = 1000000;
+	public static int reportInterval = 100000;
 	//-----------------------------------------------
 	}
 //---------------------------------------------------

--- a/src/org/dacracot/Global.java
+++ b/src/org/dacracot/Global.java
@@ -14,6 +14,9 @@ public class Global {
 	public static boolean debug = false;
 	public static boolean quiet = false;
 	public static StringBuffer activeGame = new StringBuffer();
+	// statistics
+	public static float valueSum = 0;
+	public static float varianceSum = 0;
 	//-----------------------------------------------
 	}
 //---------------------------------------------------

--- a/src/org/dacracot/Global.java
+++ b/src/org/dacracot/Global.java
@@ -19,7 +19,7 @@ public class Global {
 	public static float varianceSum = 0;
 	public static double valueHigh = 0.0;
 	public static double valueLow = 100.0;
-	public static int reportInterval = 10000;
+	public static int reportInterval = 1000000;
 	//-----------------------------------------------
 	}
 //---------------------------------------------------

--- a/src/org/dacracot/Solitaire.java
+++ b/src/org/dacracot/Solitaire.java
@@ -14,7 +14,7 @@ public class Solitaire {
 		Runtime.getRuntime().addShutdownHook(new Thread(() -> {
 			Instant end = Instant.now();
 			System.out.println("");
-			System.out.println("success: won "+Global.winner+" of "+Global.tried+" for "+String.format("%3.3f",(((1.0*Global.winner)/Global.tried)*100))+"%");
+			System.out.println("success: won "+Global.winner+" of "+Global.tried+" for "+String.format("%3.5f",(((1.0*Global.winner)/Global.tried)*100))+"%");
 			Duration between = Duration.between(Global.start, end);
 			System.out.println("");
 			System.out.format(
@@ -103,7 +103,7 @@ public class Solitaire {
 				}
 			Global.tried++;
 			if ((Global.tried % 1000000) == 0) {
-				System.out.println("progress: won "+Global.winner+" of "+Global.tried+" for "+String.format("%3.3f",(((1.0*Global.winner)/Global.tried)*100))+"%");
+				System.out.println("progress: won "+Global.winner+" of "+Global.tried+" for "+String.format("%3.5f",(((1.0*Global.winner)/Global.tried)*100))+"%");
 				}
 			}
 		//-------------------------------------------

--- a/src/org/dacracot/Solitaire.java
+++ b/src/org/dacracot/Solitaire.java
@@ -106,7 +106,7 @@ public class Solitaire {
 				}
 			Global.tried++;
 			stats.setValue((((1.0*Global.winner)/Global.tried)*100));
-			if ((Global.tried % 100000) == 0) {
+			if ((Global.tried % Global.reportInterval) == 0) {
 				Duration between = Duration.between(Global.start, Instant.now());
 				System.out.println(stats.show());
 				}

--- a/src/org/dacracot/Solitaire.java
+++ b/src/org/dacracot/Solitaire.java
@@ -105,7 +105,7 @@ public class Solitaire {
 				System.out.println("Game "+Global.tried+((Global.tries==Integer.MAX_VALUE)?" until killed":" of "+Global.tries));
 				}
 			Global.tried++;
-			stats.setValue(stats.getPercentage());
+			stats.setValue();
 			if ((Global.tried % Global.reportInterval) == 0) {
 				Duration between = Duration.between(Global.start, Instant.now());
 				System.out.println(stats.show());

--- a/src/org/dacracot/Solitaire.java
+++ b/src/org/dacracot/Solitaire.java
@@ -106,16 +106,9 @@ public class Solitaire {
 				}
 			Global.tried++;
 			stats.setValue((((1.0*Global.winner)/Global.tried)*100));
-			if ((Global.tried % 1000000) == 0) {
+			if ((Global.tried % 100000) == 0) {
 				Duration between = Duration.between(Global.start, Instant.now());
-				System.out.println(
-					"progress: won "+Global.winner+
-					" of "+Global.tried+
-					" for "+String.format("%3.5f",(((1.0*Global.winner)/Global.tried)*100))+"%,"+
-					" with a standard deviation of "+String.format("%3.7f",stats.getStdDev())+
-					" across the mean of "+String.format("%3.5f",stats.getMean())+"%"+
-					" after a duration of "+String.format("%dD, %02d:%02d:%02d",between.toDays(),between.toHoursPart(),between.toMinutesPart(),between.toSecondsPart())
-					);
+				System.out.println(stats.show());
 				}
 			}
 		//-------------------------------------------

--- a/src/org/dacracot/Solitaire.java
+++ b/src/org/dacracot/Solitaire.java
@@ -88,7 +88,6 @@ public class Solitaire {
 			(seeded?("with "+seed+" seed"):"without a seed")
 			);
 		System.out.println("");
-System.err.println("percent\tcount\tsum\tmean\tmin\tmax");
 		//-------------------------------------------
 		Global.tried=0;
 		while(Global.tried<Global.tries){

--- a/src/org/dacracot/Solitaire.java
+++ b/src/org/dacracot/Solitaire.java
@@ -4,6 +4,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Random;
 import java.util.Scanner;
+import org.dacracot.util.Statistics;
 //---------------------------------------------------
 public class Solitaire {
 	//-----------------------------------------------
@@ -86,6 +87,7 @@ public class Solitaire {
 			(seeded?("with "+seed+" seed"):"without a seed")
 			);
 		//-------------------------------------------
+		Statistics stats = new Statistics();
 		Global.tried=0;
 		while(Global.tried<Global.tries){
  			Player player = new Player(Global.cards);
@@ -102,8 +104,9 @@ public class Solitaire {
 				System.out.println("Game "+Global.tried+((Global.tries==Integer.MAX_VALUE)?" until killed":" of "+Global.tries));
 				}
 			Global.tried++;
+			stats.setValue((((1.0*Global.winner)/Global.tried)*100));
 			if ((Global.tried % 1000000) == 0) {
-				System.out.println("progress: won "+Global.winner+" of "+Global.tried+" for "+String.format("%3.5f",(((1.0*Global.winner)/Global.tried)*100))+"%");
+				System.out.println("progress: won "+Global.winner+" of "+Global.tried+" for "+String.format("%3.5f",(((1.0*Global.winner)/Global.tried)*100))+"%, with a standard deviation of "+String.format("%3.7f",stats.getStdDev())+" across the mean of "+String.format("%3.5f",stats.getMean())+"%");
 				}
 			}
 		//-------------------------------------------

--- a/src/org/dacracot/Solitaire.java
+++ b/src/org/dacracot/Solitaire.java
@@ -11,11 +11,12 @@ public class Solitaire {
 	public Solitaire(){}
 	//-----------------------------------------------
 	public static void main(String[] args){
+		Statistics stats = new Statistics();
 		//-------------------------------------------
 		Runtime.getRuntime().addShutdownHook(new Thread(() -> {
 			Instant end = Instant.now();
 			System.out.println("");
-			System.out.println("success: won "+Global.winner+" of "+Global.tried+" for "+String.format("%3.5f",(((1.0*Global.winner)/Global.tried)*100))+"%");
+			System.out.println("success: won "+Global.winner+" of "+Global.tried+" for "+String.format("%3.5f",stats.getPercentage())+"%");
 			Duration between = Duration.between(Global.start, end);
 			System.out.println("");
 			System.out.format(
@@ -88,7 +89,6 @@ public class Solitaire {
 			);
 		System.out.println("");
 		//-------------------------------------------
-		Statistics stats = new Statistics();
 		Global.tried=0;
 		while(Global.tried<Global.tries){
  			Player player = new Player(Global.cards);
@@ -105,7 +105,7 @@ public class Solitaire {
 				System.out.println("Game "+Global.tried+((Global.tries==Integer.MAX_VALUE)?" until killed":" of "+Global.tries));
 				}
 			Global.tried++;
-			stats.setValue((((1.0*Global.winner)/Global.tried)*100));
+			stats.setValue(stats.getPercentage());
 			if ((Global.tried % Global.reportInterval) == 0) {
 				Duration between = Duration.between(Global.start, Instant.now());
 				System.out.println(stats.show());

--- a/src/org/dacracot/Solitaire.java
+++ b/src/org/dacracot/Solitaire.java
@@ -106,7 +106,15 @@ public class Solitaire {
 			Global.tried++;
 			stats.setValue((((1.0*Global.winner)/Global.tried)*100));
 			if ((Global.tried % 1000000) == 0) {
-				System.out.println("progress: won "+Global.winner+" of "+Global.tried+" for "+String.format("%3.5f",(((1.0*Global.winner)/Global.tried)*100))+"%, with a standard deviation of "+String.format("%3.7f",stats.getStdDev())+" across the mean of "+String.format("%3.5f",stats.getMean())+"%");
+				Duration between = Duration.between(Global.start, Instant.now());
+				System.out.println(
+					"progress: won "+Global.winner+
+					" of "+Global.tried+
+					" for "+String.format("%3.5f",(((1.0*Global.winner)/Global.tried)*100))+"%,"+
+					" with a standard deviation of "+String.format("%3.7f",stats.getStdDev())+
+					" across the mean of "+String.format("%3.5f",stats.getMean())+"%"+
+					" after a duration of "+String.format(" %dD, %02d:%02d:%02d",between.toDays(),between.toHoursPart(),between.toMinutesPart(),between.toSecondsPart())
+					);
 				}
 			}
 		//-------------------------------------------

--- a/src/org/dacracot/Solitaire.java
+++ b/src/org/dacracot/Solitaire.java
@@ -88,6 +88,7 @@ public class Solitaire {
 			(seeded?("with "+seed+" seed"):"without a seed")
 			);
 		System.out.println("");
+System.err.println("percent\tcount\tsum\tmean\tmin\tmax");
 		//-------------------------------------------
 		Global.tried=0;
 		while(Global.tried<Global.tries){

--- a/src/org/dacracot/Solitaire.java
+++ b/src/org/dacracot/Solitaire.java
@@ -101,15 +101,10 @@ public class Solitaire {
 					}
  				}
   			Global.activeGame.delete(0, Global.activeGame.length());
-			if (!Global.quiet) {
-				System.out.println("Game "+Global.tried+((Global.tries==Integer.MAX_VALUE)?" until killed":" of "+Global.tries));
-				}
+			if (!Global.quiet) System.out.println("Game "+Global.tried+((Global.tries==Integer.MAX_VALUE)?" until killed":" of "+Global.tries));
 			Global.tried++;
-			stats.setValue();
-			if ((Global.tried % Global.reportInterval) == 0) {
-				Duration between = Duration.between(Global.start, Instant.now());
-				System.out.println(stats.show());
-				}
+			if (Global.tried >= Global.waitForSteadyState) stats.setValue();
+			if ((Global.tried % Global.reportInterval) == 0) System.out.println(stats.show());
 			}
 		//-------------------------------------------
 		}

--- a/src/org/dacracot/Solitaire.java
+++ b/src/org/dacracot/Solitaire.java
@@ -102,6 +102,9 @@ public class Solitaire {
 				System.out.println("Game "+Global.tried+((Global.tries==Integer.MAX_VALUE)?" until killed":" of "+Global.tries));
 				}
 			Global.tried++;
+			if ((Global.tried % 1000000) == 0) {
+				System.out.println("progress: won "+Global.winner+" of "+Global.tried+" for "+String.format("%3.3f",(((1.0*Global.winner)/Global.tried)*100))+"%");
+				}
 			}
 		//-------------------------------------------
 		}

--- a/src/org/dacracot/Solitaire.java
+++ b/src/org/dacracot/Solitaire.java
@@ -86,6 +86,7 @@ public class Solitaire {
 			(Global.debug?"with":"without")+" debug "+
 			(seeded?("with "+seed+" seed"):"without a seed")
 			);
+		System.out.println("");
 		//-------------------------------------------
 		Statistics stats = new Statistics();
 		Global.tried=0;
@@ -113,7 +114,7 @@ public class Solitaire {
 					" for "+String.format("%3.5f",(((1.0*Global.winner)/Global.tried)*100))+"%,"+
 					" with a standard deviation of "+String.format("%3.7f",stats.getStdDev())+
 					" across the mean of "+String.format("%3.5f",stats.getMean())+"%"+
-					" after a duration of "+String.format(" %dD, %02d:%02d:%02d",between.toDays(),between.toHoursPart(),between.toMinutesPart(),between.toSecondsPart())
+					" after a duration of "+String.format("%dD, %02d:%02d:%02d",between.toDays(),between.toHoursPart(),between.toMinutesPart(),between.toSecondsPart())
 					);
 				}
 			}

--- a/src/org/dacracot/table/Board.java
+++ b/src/org/dacracot/table/Board.java
@@ -61,6 +61,7 @@ public class Board {
 	//-----------------------------------------------
 	public ArrayList<Card> getUpCardsFromTop() {
 		ArrayList<Card> up = new ArrayList<Card>();
+		// smallest initial to longest initial
 		for(int i=0; i<SEVEN; i++) {
 			for(Card card : columns.get(i)) {
 				if (!card.isHidden()) {
@@ -73,14 +74,15 @@ public class Board {
 		}
 	//-----------------------------------------------
 	public ArrayList<Card> getUpCardsFromBottom() {
-		ArrayList<Card> up = new ArrayList<Card>();
+		ArrayList<Card> bottom = new ArrayList<Card>();
+		// smallest initial to longest initial
 		for(int i=0; i<SEVEN; i++) {
 			try {
-				up.add(columns.get(i).get(columns.get(i).size()-1));
+				bottom.add(columns.get(i).get(columns.get(i).size()-1));
 				}
 			catch(IndexOutOfBoundsException e) {} // empty columns have no up card
 			}
-		return(up);
+		return(bottom);
 		}
 	//-----------------------------------------------
 	public boolean playCard(Card source) {

--- a/src/org/dacracot/util/Statistics.java
+++ b/src/org/dacracot/util/Statistics.java
@@ -1,11 +1,15 @@
 package org.dacracot.util;
 //---------------------------------------------------
+import java.time.Duration;
+import java.time.Instant;
 import org.dacracot.Global;
 //---------------------------------------------------
 public class Statistics {
 	//-----------------------------------------------
 	public void setValue(double value) {
 		Global.valueSum+= value;
+		if (value > Global.valueHigh) Global.valueHigh = value;
+		if (value < Global.valueLow) Global.valueLow = value;
 		Global.varianceSum+= Math.pow((value - getMean()),2);
 		}
 	//-----------------------------------------------
@@ -15,6 +19,20 @@ public class Statistics {
 	//-----------------------------------------------
 	public double getStdDev() {
 		return(Math.sqrt(Global.varianceSum/Global.tried));
+		}
+	//-----------------------------------------------
+	public String show() {
+		Duration between = Duration.between(Global.start, Instant.now());
+		return(String.format(
+			"stats: won "+Global.winner+
+			" of "+Global.tried+
+			" for "+String.format("%3.5f",(((1.0*Global.winner)/Global.tried)*100))+"%,"+
+			" with a standard deviation of "+String.format("%3.7f",getStdDev())+
+			" across the mean of "+String.format("%3.5f",getMean())+"%"+
+			" with max of "+String.format("%3.5f",Global.valueHigh)+"%"+
+			" with min of "+String.format("%3.5f",Global.valueLow)+"%"+
+			" after a duration of "+String.format("%dD, %02d:%02d:%02d",between.toDays(),between.toHoursPart(),between.toMinutesPart(),between.toSecondsPart())
+			));
 		}
 	//-----------------------------------------------
 }

--- a/src/org/dacracot/util/Statistics.java
+++ b/src/org/dacracot/util/Statistics.java
@@ -1,0 +1,21 @@
+package org.dacracot.util;
+//---------------------------------------------------
+import org.dacracot.Global;
+//---------------------------------------------------
+public class Statistics {
+	//-----------------------------------------------
+	public void setValue(double value) {
+		Global.valueSum+= value;
+		Global.varianceSum+= Math.pow(value - getMean(), 2);
+		}
+	//-----------------------------------------------
+	public double getMean() {
+		return(Global.valueSum/Global.tried);
+		}
+	//-----------------------------------------------
+	public double getStdDev() {
+		return(Math.sqrt(Global.varianceSum/Global.tried));
+		}
+	//-----------------------------------------------
+}
+//-----------------------------------------------

--- a/src/org/dacracot/util/Statistics.java
+++ b/src/org/dacracot/util/Statistics.java
@@ -13,8 +13,6 @@ public class Statistics {
 		Global.varianceSum+= Math.pow((percent - getMean()),2);
 		if (percent > Global.valueHigh) Global.valueHigh = percent;
 		if (percent < Global.valueLow) Global.valueLow = percent;
-// System.out.println(show());
-// System.out.println("count: "+Global.count);
 		}
 	//-----------------------------------------------
 	public double getMean() {

--- a/src/org/dacracot/util/Statistics.java
+++ b/src/org/dacracot/util/Statistics.java
@@ -8,8 +8,10 @@ public class Statistics {
 	//-----------------------------------------------
 	public void setValue(double value) {
 		Global.valueSum+= value;
-		if (value > Global.valueHigh) Global.valueHigh = value;
-		if (value < Global.valueLow) Global.valueLow = value;
+		if (Global.tried > (Global.reportInterval-1)) {
+			if (value > Global.valueHigh) Global.valueHigh = value;
+			if (value < Global.valueLow) Global.valueLow = value;
+			}
 		Global.varianceSum+= Math.pow((value - getMean()),2);
 		}
 	//-----------------------------------------------
@@ -23,7 +25,7 @@ public class Statistics {
 	//-----------------------------------------------
 	public String show() {
 		Duration between = Duration.between(Global.start, Instant.now());
-		return(String.format(
+		return(
 			"stats: won "+Global.winner+
 			" of "+Global.tried+
 			" for "+String.format("%3.5f",(((1.0*Global.winner)/Global.tried)*100))+"%,"+
@@ -32,7 +34,7 @@ public class Statistics {
 			" with max of "+String.format("%3.5f",Global.valueHigh)+"%"+
 			" with min of "+String.format("%3.5f",Global.valueLow)+"%"+
 			" after a duration of "+String.format("%dD, %02d:%02d:%02d",between.toDays(),between.toHoursPart(),between.toMinutesPart(),between.toSecondsPart())
-			));
+			);
 		}
 	//-----------------------------------------------
 }

--- a/src/org/dacracot/util/Statistics.java
+++ b/src/org/dacracot/util/Statistics.java
@@ -8,20 +8,21 @@ public class Statistics {
 	//-----------------------------------------------
 	public void setValue() {
 		double percent = getPercentage();
+		Global.count++;
 		Global.valueSum+= percent;
-		if (Global.tried >= (Global.reportInterval-1)) {
-			if (percent > Global.valueHigh) Global.valueHigh = percent;
-			if (percent < Global.valueLow) Global.valueLow = percent;
-			}
 		Global.varianceSum+= Math.pow((percent - getMean()),2);
+		if (percent > Global.valueHigh) Global.valueHigh = percent;
+		if (percent < Global.valueLow) Global.valueLow = percent;
+// System.out.println(show());
+// System.out.println("count: "+Global.count);
 		}
 	//-----------------------------------------------
 	public double getMean() {
-		return(Global.valueSum/Global.tried);
+		return(Global.valueSum/Global.count);
 		}
 	//-----------------------------------------------
 	public double getStdDev() {
-		return(Math.sqrt(Global.varianceSum/Global.tried));
+		return(Math.sqrt(Global.varianceSum/Global.count));
 		}
 	//-----------------------------------------------
 	public double getPercentage() {

--- a/src/org/dacracot/util/Statistics.java
+++ b/src/org/dacracot/util/Statistics.java
@@ -8,9 +8,11 @@ public class Statistics {
 	//-----------------------------------------------
 	public void setValue() {
 		double percent = getPercentage();
+		double oldMean = getMean();
 		Global.count++;
 		Global.valueSum+= percent;
-		Global.varianceSum+= Math.pow((percent - getMean()),2);
+		double newMean = getMean();
+		Global.varianceSum+= (percent - oldMean) * (percent - newMean);
 		if (percent > Global.valueHigh) Global.valueHigh = percent;
 		if (percent < Global.valueLow) Global.valueLow = percent;
 		}
@@ -42,4 +44,4 @@ public class Statistics {
 		}
 	//-----------------------------------------------
 }
-//-----------------------------------------------
+//---------------------------------------------------

--- a/src/org/dacracot/util/Statistics.java
+++ b/src/org/dacracot/util/Statistics.java
@@ -6,11 +6,12 @@ import org.dacracot.Global;
 //---------------------------------------------------
 public class Statistics {
 	//-----------------------------------------------
-	public void setValue(double value) {
-		Global.valueSum+= value;
-		if (Global.tried > (Global.reportInterval-1)) {
-			if (value > Global.valueHigh) Global.valueHigh = value;
-			if (value < Global.valueLow) Global.valueLow = value;
+	public void setValue() {
+		double percent = getPercentage();
+		Global.valueSum+= percent;
+		if (Global.tried >= (Global.reportInterval-1)) {
+			if (percent > Global.valueHigh) Global.valueHigh = percent;
+			if (percent < Global.valueLow) Global.valueLow = percent;
 			}
 		Global.varianceSum+= Math.pow((value - getMean()),2);
 		}
@@ -23,12 +24,16 @@ public class Statistics {
 		return(Math.sqrt(Global.varianceSum/Global.tried));
 		}
 	//-----------------------------------------------
+	public double getPercentage() {
+		return(((1.0*Global.winner)/Global.tried)*100);
+		}
+	//-----------------------------------------------
 	public String show() {
 		Duration between = Duration.between(Global.start, Instant.now());
 		return(
 			"stats: won "+Global.winner+
 			" of "+Global.tried+
-			" for "+String.format("%3.5f",(((1.0*Global.winner)/Global.tried)*100))+"%,"+
+			" for "+String.format("%3.5f",getPercentage())+"%,"+
 			" with a standard deviation of "+String.format("%3.7f",getStdDev())+
 			" across the mean of "+String.format("%3.5f",getMean())+"%"+
 			" with max of "+String.format("%3.5f",Global.valueHigh)+"%"+

--- a/src/org/dacracot/util/Statistics.java
+++ b/src/org/dacracot/util/Statistics.java
@@ -13,7 +13,7 @@ public class Statistics {
 			if (percent > Global.valueHigh) Global.valueHigh = percent;
 			if (percent < Global.valueLow) Global.valueLow = percent;
 			}
-		Global.varianceSum+= Math.pow((value - getMean()),2);
+		Global.varianceSum+= Math.pow((percent - getMean()),2);
 		}
 	//-----------------------------------------------
 	public double getMean() {

--- a/src/org/dacracot/util/Statistics.java
+++ b/src/org/dacracot/util/Statistics.java
@@ -6,7 +6,7 @@ public class Statistics {
 	//-----------------------------------------------
 	public void setValue(double value) {
 		Global.valueSum+= value;
-		Global.varianceSum+= Math.pow(value - getMean(), 2);
+		Global.varianceSum+= Math.pow((value - getMean()),2);
 		}
 	//-----------------------------------------------
 	public double getMean() {

--- a/src/org/dacracot/util/Statistics.java
+++ b/src/org/dacracot/util/Statistics.java
@@ -8,11 +8,9 @@ public class Statistics {
 	//-----------------------------------------------
 	public void setValue() {
 		double percent = getPercentage();
-		double oldMean = getMean();
 		Global.count++;
 		Global.valueSum+= percent;
-		double newMean = getMean();
-		Global.varianceSum+= (percent - oldMean) * (percent - newMean);
+		Global.varianceSum+= Math.pow((percent - getMean()),2);
 		if (percent > Global.valueHigh) Global.valueHigh = percent;
 		if (percent < Global.valueLow) Global.valueLow = percent;
 		}
@@ -36,7 +34,7 @@ public class Statistics {
 			" of "+Global.tried+
 			" for "+String.format("%3.5f",getPercentage())+"%,"+
 			" with a standard deviation of "+String.format("%3.7f",getStdDev())+
-			" across the mean of "+String.format("%3.5f",getMean())+"%"+
+			" from the mean of "+String.format("%3.5f",getMean())+"%"+
 			" with max of "+String.format("%3.5f",Global.valueHigh)+"%"+
 			" with min of "+String.format("%3.5f",Global.valueLow)+"%"+
 			" after a duration of "+String.format("%dD, %02d:%02d:%02d",between.toDays(),between.toHoursPart(),between.toMinutesPart(),between.toSecondsPart())


### PR DESCRIPTION
Thought I was going to create a definitive stopping point for calculating the winning percentage, but instead all of the statistics I created proved the well distributed randomness of the deck shuffling, creating an ever drifting winning percentage at a relatively low precision.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a `Statistics` class that tracks the running win-percentage mean, standard deviation, and high/low across long simulation runs, and wires periodic reporting (every 1 million games) into the main loop. It also adds a `--continuous` flag, documents a 24-hour benchmark invocation, and renames a local variable in `Board.java` for clarity.

- **`Statistics.java`**: samples `getPercentage()` after every game once `tried >= waitForSteadyState` (game 999,900), accumulating sum, variance, and extremes in global state; `show()` prints a formatted snapshot of all five statistics plus elapsed duration.
- **`Solitaire.java`**: integrates `Statistics` into the main loop; the `show()` output fires unconditionally (not gated by `--quiet`) every `reportInterval` games, which is appropriate since quiet mode is meant to silence per-game lines, not the aggregate report.
- **`Global.java`**: adds six new statistics fields; `waitForSteadyState = reportInterval - 100` means only the final 100 games of each million-game window contribute to the first stats snapshot.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all changes are additive and the new statistics path does not alter existing game logic.

The statistics accumulation, periodic reporting, and new global fields are all additive. Existing game-play logic in Player, Board, and the main loop is unchanged apart from the two new lines that call setValue() and show(). The only fragile spot is the implicit assumption in getMean() that count > 0 when show() is called, but the hardcoded relationship between reportInterval and waitForSteadyState guarantees this today.

src/org/dacracot/util/Statistics.java — the getMean() guard and biased-variance divisor are worth a second look before the reporting interval is ever made configurable at runtime.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/org/dacracot/util/Statistics.java | New class implementing running win-percentage statistics (mean, stddev, high, low); variance formula uses post-update mean so `(x − new_mean)²` terms are always slightly pulled inward, and `getMean()` has no guard for count == 0. |
| src/org/dacracot/Global.java | Adds six new static fields for statistics accumulation; `waitForSteadyState = reportInterval - 100` hard-codes only 100 warm-up games before the first stats sample window, which is tight but intentional. |
| src/org/dacracot/Solitaire.java | Wires in the Statistics object; periodic `show()` output fires unconditionally (not gated by `--quiet`) every `reportInterval` games, which is the intended behavior for continuous mode monitoring. |
| src/org/dacracot/table/Board.java | Renames local variable `up` → `bottom` in `getUpCardsFromBottom()` for clarity; adds a comment; no logic changes. |
| README.md | Updates timing estimate (< 1 hour → ~20 min on M2) and documents the new `--quiet --continuous` usage pattern for the statistics feature. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[main loop: run game] --> B[Global.tried++]
    B --> C{tried >= waitForSteadyState 999900?}
    C -- Yes --> D[stats.setValue
getPercentage → count++ → valueSum → varianceSum → hi/lo]
    C -- No --> E{tried % reportInterval == 0?}
    D --> E
    E -- Yes --> F[System.out.println stats.show
mean · stddev · hi · lo · duration]
    E -- No --> G[continue loop]
    F --> G
    G --> A
    H[SIGINT / end of tries] --> I[shutdown hook]
    I --> J[stats.getPercentage
winner/tried × 100]
    J --> K[print final summary + duration]
```

<sub>Reviews (2): Last reviewed commit: ["spelling typo"](https://github.com/dacracot/klondike3-simulator/commit/eee53ce35d86643bcc27b00b7057dbdf5e372781) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32462015)</sub>

<!-- /greptile_comment -->