### PR TITLE
Better debug reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ---
 
 ## Versions
-- 1.7
+- 1.7, 1.7.1
   - While the intent was to create multi-threaded players, the change to better log buffer management resulted in a nearly 20 times increase in speed.
 - 1.6
   - Play altered to sort b2b to ascending or descending column's hidden card count rather than left to right. Winning percentage increased from 8.54274%[^1] to 11.74316%.

--- a/src/org/dacracot/Player.java
+++ b/src/org/dacracot/Player.java
@@ -21,6 +21,7 @@ public class Player {
 		FromGoal fromGoal = new FromGoal(game);
 		if (Global.debug){activeGame.append(game.showAll("Ready to Play"));}
 		//-------------------------------------------
+		boolean won = false;
 		int loops = 0;
 		int flops = 0;
 		// Play until there are no moves for three loops.
@@ -57,11 +58,18 @@ public class Player {
 					System.out.println("================== WINNER ==================");
 					System.out.println(activeGame);
 					System.out.println("================== WINNER ==================");
-					activeGame.delete(0, activeGame.length());
 					}
+				won = true;
 				Global.win();
 				break;
 				}
+			}
+		//-------------------------------------------
+		if ((Global.debug) && (!won)){activeGame.append(game.showAll("loser >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops)));}
+		if ((Global.debug) && (!won)) {
+			System.out.println("================== LOSER ==================");
+			System.out.println(activeGame);
+			System.out.println("================== LOSER ==================");
 			}
 		//-------------------------------------------
 		}


### PR DESCRIPTION
report game details for losing attempts as well as winners while in debug mode

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends debug mode to also print the full game trace for losing games, complementing the existing winner reporting. A `won` boolean is introduced to distinguish win/loss outcomes after the main play loop.

- `Player.java`: adds `won = false` tracking; moves `won = true` and `Global.win()` outside the debug-only block so the win flag is always set correctly; removes the now-unnecessary `activeGame.delete()` call (safe because a new `Player` is created per game); adds a loser debug-output section after the main loop.
- `README.md`: version entry updated to include 1.7.1.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the change only adds loser debug output and does not touch game logic or global state.

The logic for tracking the win/loss outcome is correct, and the removed buffer-clear is harmless given that a fresh Player is created per game. The only rough edge is two consecutive if blocks checking the same condition for the loser path, a style nit with no functional impact.

No files require special attention; the changes are self-contained within Player.java.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/org/dacracot/Player.java | Adds a `won` boolean to track game outcome; prints loser debug state after the main loop when in debug mode. The `activeGame` buffer is no longer cleared after a winner is reported, which is safe because a new `Player` instance is created for each game. Two separate `if` blocks check the same condition for the loser path. |
| README.md | Version number updated to include 1.7.1 alongside 1.7; no functional content changes. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[play start] --> B[Initialize game and activeGame buffer]
    B --> C{flops less than 3?}
    C -- yes --> D[Execute moves: fromStack, fromBoard, stack.flip]
    D --> E{game.goal.winner?}
    E -- no --> C
    E -- yes --> F[debug: append and print WINNER]
    F --> G[won = true, Global.win, break]
    C -- no --> H{debug AND not won?}
    G --> H
    H -- yes --> I[append and print LOSER state]
    H -- no --> J[done]
    I --> J
```

<sub>Reviews (1): Last reviewed commit: ["report game details for losing attempts ..."](https://github.com/dacracot/klondike3-simulator/commit/d147f3b2e2ae42e6e29b08cf5e4fddb89429d2da) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34256108)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->