### PR TITLE
mass find and replace StringBuffer with StringBuilder

### DIFF
--- a/src/org/dacracot/Klondike.java
+++ b/src/org/dacracot/Klondike.java
@@ -23,7 +23,7 @@ public class Klondike{
 		}
 	//-----------------------------------------------
 	public String showAll(String title) {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("~~~~~~~~~~~~~~~~~~\n");
 		sb.append("~~~ "+title+" ~~~~~~~~~\n");
 		sb.append(goal.show());

--- a/src/org/dacracot/Player.java
+++ b/src/org/dacracot/Player.java
@@ -7,7 +7,7 @@ import org.dacracot.move.FromGoal;
 public class Player {
 	//-----------------------------------------------
 	private int cards;
-	private StringBuffer activeGame = new StringBuffer();
+	private StringBuilder activeGame = new StringBuilder();
 	//-----------------------------------------------
 	public Player(int cards){
 		this.cards = cards;

--- a/src/org/dacracot/table/Board.java
+++ b/src/org/dacracot/table/Board.java
@@ -189,7 +189,7 @@ public class Board {
 		return(playable);
 		}
 	//-----------------------------------------------
-	private void showColumn(ArrayList<Card> g, StringBuffer sb) {
+	private void showColumn(ArrayList<Card> g, StringBuilder sb) {
 		for(int i=0; i<g.size(); i++){
 			sb.append(g.get(i).draw());
 			}
@@ -197,7 +197,7 @@ public class Board {
 		}
 	//-----------------------------------------------
 	public String show(){
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("======================\n");
 		sb.append("=== Board ============\n");
 		for(int i=0; i<SEVEN; i++) {

--- a/src/org/dacracot/table/Goal.java
+++ b/src/org/dacracot/table/Goal.java
@@ -53,7 +53,7 @@ public class Goal {
 		return(false);
 		}
 	//-----------------------------------------------
-	private void showGoal(ArrayList<Card> g, StringBuffer sb){
+	private void showGoal(ArrayList<Card> g, StringBuilder sb){
 		for(int i=0; i<g.size(); i++){
 			sb.append(g.get(i).draw());
 			}
@@ -61,7 +61,7 @@ public class Goal {
 		}
 	//-----------------------------------------------
 	public String show(){
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("======================\n");
 		sb.append("=== Goal =============\n");
 		showGoal(spades,sb);

--- a/src/org/dacracot/table/Stack.java
+++ b/src/org/dacracot/table/Stack.java
@@ -66,7 +66,7 @@ public class Stack {
 		return(down.size());
 		}
 	//-----------------------------------------------
-	private void showStack(ArrayList<Card> g, StringBuffer sb){
+	private void showStack(ArrayList<Card> g, StringBuilder sb){
 		for(int i=0; i<g.size(); i++){
 			sb.append(g.get(i).draw());
 			}
@@ -74,7 +74,7 @@ public class Stack {
 		}
 	//-----------------------------------------------
 	public String show(){
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("======================\n");
 		sb.append("=== Stack ============\n");
 		showStack(down,sb);


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR performs a mechanical find-and-replace of `StringBuffer` with `StringBuilder` across five files. The change is appropriate: none of the replaced instances are accessed from multiple threads, so the synchronized overhead of `StringBuffer` was never needed.

- **`Player.java`**: The instance field `activeGame` is the only non-local replacement. Verified safe — `Player` objects are created fresh each iteration in a single-threaded loop in `Solitaire.java` and `play()` is called exactly once per instance.
- **`Board.java`, `Goal.java`, `Stack.java`, `Klondike.java`**: All replacements are either local variables within `show()` methods or helper-method parameters; no thread-safety concerns in any of these cases.

<h3>Confidence Score: 5/5</h3>

All replacements are correct and safe to merge.

Every replaced StringBuffer is either a method-local variable or a helper-method parameter; the one instance field (activeGame in Player) is confirmed single-threaded — a fresh Player is constructed per iteration and play() is invoked once. No behavioral change is introduced.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/org/dacracot/Player.java | Instance field `activeGame` changed from `StringBuffer` to `StringBuilder`; safe because `Player` instances are created fresh per game in a single-threaded loop and never shared across threads. |
| src/org/dacracot/table/Board.java | Local variable and helper-method parameter both switched to `StringBuilder`; correct, no thread sharing. |
| src/org/dacracot/table/Goal.java | Local variable and helper-method parameter both switched to `StringBuilder`; correct, no thread sharing. |
| src/org/dacracot/table/Stack.java | Local variable and helper-method parameter both switched to `StringBuilder`; correct, no thread sharing. |
| src/org/dacracot/Klondike.java | Local variable `sb` in `showAll()` switched from `StringBuffer` to `StringBuilder`; correct change with no threading concerns. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant S as Solitaire (main)
    participant P as Player
    participant K as Klondike
    participant B as Board
    participant G as Goal
    participant St as Stack

    loop per game attempt
        S->>P: new Player(cards)
        S->>P: play()
        P->>K: new Klondike(cards)
        P->>K: showAll(title)
        K->>B: show() — StringBuilder (local)
        K->>G: show() — StringBuilder (local)
        K->>St: show() — StringBuilder (local)
        K-->>P: appended to activeGame (StringBuilder field)
    end
```

<sub>Reviews (1): Last reviewed commit: ["mass find and replace StringBuffer with ..."](https://github.com/dacracot/klondike3-simulator/commit/f417af93ece626b5e6482e0982fbaddec698e3cb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36129436)</sub>

<!-- /greptile_comment -->