### PR TITLE
Issue 91

### DIFF
--- a/src/org/dacracot/Global.java
+++ b/src/org/dacracot/Global.java
@@ -13,6 +13,7 @@ public class Global {
 	public static int tries = 10;
 	public static Random random = null;
 	public static boolean debug = false;
+	public static boolean watch = false;
 	public static boolean quiet = false;
 	//-----------------------------------------------
 	public static double valueSum = 0;

--- a/src/org/dacracot/Player.java
+++ b/src/org/dacracot/Player.java
@@ -20,10 +20,12 @@ public class Player {
 		FromTableau fromTableau = new FromTableau(game);
 		FromFoundation fromFoundation = new FromFoundation(game);
 		if (Global.debug){activeGame.append(game.showAll("Ready to Play"));}
+		if (Global.watch){System.out.println(game.showAll("Ready to Play"));}
 		//-------------------------------------------
 		boolean won = false;
 		int loops = 0;
 		int flops = 0;
+	try {
 		// Play until there are no moves for three loops.
 		while(flops < 3) {
 			// Play only one (or none) from deck to foundation
@@ -32,11 +34,11 @@ public class Player {
 				flops = 0;
 				}
 			if (Global.debug){activeGame.append(game.showAll("d2f   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops)));}
-			if (Global.watch){game.showAll("d2f   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops));System.out.print("\033[23F");}
+			if (Global.watch){System.out.println(game.showAll("d2f   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops))+"\033[23F");Thread.sleep(1000);}
 			// Play tableau to tableau until no more moves available
 			while(fromTableau.toTableau()) {
 				if (Global.debug){activeGame.append(game.showAll("t2t   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops)));}
-				if (Global.watch){game.showAll("t2t   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops));System.out.print("\033[23F");}
+				if (Global.watch){System.out.println(game.showAll("t2t   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops))+"\033[23F");Thread.sleep(1000);}
 				}
 			// Play only one (or none) from tableau to foundation
 			if (fromTableau.toFoundation()) {
@@ -44,18 +46,18 @@ public class Player {
 				flops = 0;
 				}
 			if (Global.debug){activeGame.append(game.showAll("t2f   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops)));}
-			if (Global.watch){game.showAll("t2f   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops));System.out.print("\033[23F");}
+			if (Global.watch){System.out.println(game.showAll("t2f   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops))+"\033[23F");Thread.sleep(1000);}
 			// Play deck to tableau until no more moves available
 			while(fromDeck.toTableau()) {
 				if (Global.debug){activeGame.append(game.showAll("d2t   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops)));}
-				if (Global.watch){game.showAll("d2t   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops));System.out.print("\033[23F");}
+				if (Global.watch){System.out.println(game.showAll("d2t   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops))+"\033[23F");Thread.sleep(1000);}
 				}
 			// Turn over the deck
 			if (game.deck.flip()) {
 				flops++;
 				}
 			if (Global.debug){activeGame.append(game.showAll("s.flip >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops)));}
-			if (Global.watch){game.showAll("s.flip >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops));System.out.print("\033[23F");}
+			if (Global.watch){System.out.println(game.showAll("s.flip >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops))+"\033[23F");Thread.sleep(1000);}
 			// Did we win by putting all cards in the foundation?
 			if (game.foundation.winner()) {
  				if (Global.debug) {
@@ -69,6 +71,10 @@ public class Player {
 				break;
 				}
 			}
+		}
+	catch (Exception e) {
+		System.err.println(e);
+		}
 		//-------------------------------------------
 		if ((Global.debug) && (!won)) {
 			activeGame.append(game.showAll("loser >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops)));

--- a/src/org/dacracot/Player.java
+++ b/src/org/dacracot/Player.java
@@ -32,9 +32,11 @@ public class Player {
 				flops = 0;
 				}
 			if (Global.debug){activeGame.append(game.showAll("d2f   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops)));}
+			if (Global.watch){game.showAll("d2f   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops));System.out.print("\033[23F");}
 			// Play tableau to tableau until no more moves available
 			while(fromTableau.toTableau()) {
 				if (Global.debug){activeGame.append(game.showAll("t2t   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops)));}
+				if (Global.watch){game.showAll("t2t   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops));System.out.print("\033[23F");}
 				}
 			// Play only one (or none) from tableau to foundation
 			if (fromTableau.toFoundation()) {
@@ -42,15 +44,18 @@ public class Player {
 				flops = 0;
 				}
 			if (Global.debug){activeGame.append(game.showAll("t2f   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops)));}
+			if (Global.watch){game.showAll("t2f   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops));System.out.print("\033[23F");}
 			// Play deck to tableau until no more moves available
 			while(fromDeck.toTableau()) {
 				if (Global.debug){activeGame.append(game.showAll("d2t   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops)));}
+				if (Global.watch){game.showAll("d2t   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops));System.out.print("\033[23F");}
 				}
 			// Turn over the deck
 			if (game.deck.flip()) {
 				flops++;
 				}
 			if (Global.debug){activeGame.append(game.showAll("s.flip >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops)));}
+			if (Global.watch){game.showAll("s.flip >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops));System.out.print("\033[23F");}
 			// Did we win by putting all cards in the foundation?
 			if (game.foundation.winner()) {
  				if (Global.debug) {

--- a/src/org/dacracot/Player.java
+++ b/src/org/dacracot/Player.java
@@ -13,6 +13,18 @@ public class Player {
 		this.cards = cards;
 		}
 	//-----------------------------------------------
+	private void watcher() {
+		try {
+			Thread.sleep(1000); // wait 1 seconds
+			System.out.print("\033[H\033[2J"); // clear screen
+			System.out.flush();
+			}
+		catch (Exception e) {
+			System.err.println(e);
+			System.exit(1);
+			}
+		}
+	//-----------------------------------------------
 	public void play() {
 		Global.play();
 		Klondike game = new Klondike(cards);
@@ -20,12 +32,11 @@ public class Player {
 		FromTableau fromTableau = new FromTableau(game);
 		FromFoundation fromFoundation = new FromFoundation(game);
 		if (Global.debug){activeGame.append(game.showAll("Ready to Play"));}
-		if (Global.watch){System.out.println(game.showAll("Ready to Play"));}
+		if (Global.watch){System.out.print("\033[H\033[2J");System.out.flush();System.out.println(game.showAll("Ready to Play"));watcher();}
 		//-------------------------------------------
 		boolean won = false;
 		int loops = 0;
 		int flops = 0;
-	try {
 		// Play until there are no moves for three loops.
 		while(flops < 3) {
 			// Play only one (or none) from deck to foundation
@@ -34,11 +45,11 @@ public class Player {
 				flops = 0;
 				}
 			if (Global.debug){activeGame.append(game.showAll("d2f   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops)));}
-			if (Global.watch){System.out.println(game.showAll("d2f   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops))+"\033[23F");Thread.sleep(1000);}
+			if (Global.watch){System.out.println(game.showAll("d2f   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops)));watcher();}
 			// Play tableau to tableau until no more moves available
 			while(fromTableau.toTableau()) {
 				if (Global.debug){activeGame.append(game.showAll("t2t   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops)));}
-				if (Global.watch){System.out.println(game.showAll("t2t   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops))+"\033[23F");Thread.sleep(1000);}
+				if (Global.watch){System.out.println(game.showAll("t2t   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops)));watcher();}
 				}
 			// Play only one (or none) from tableau to foundation
 			if (fromTableau.toFoundation()) {
@@ -46,18 +57,18 @@ public class Player {
 				flops = 0;
 				}
 			if (Global.debug){activeGame.append(game.showAll("t2f   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops)));}
-			if (Global.watch){System.out.println(game.showAll("t2f   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops))+"\033[23F");Thread.sleep(1000);}
+			if (Global.watch){System.out.println(game.showAll("t2f   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops)));watcher();}
 			// Play deck to tableau until no more moves available
 			while(fromDeck.toTableau()) {
 				if (Global.debug){activeGame.append(game.showAll("d2t   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops)));}
-				if (Global.watch){System.out.println(game.showAll("d2t   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops))+"\033[23F");Thread.sleep(1000);}
+				if (Global.watch){System.out.println(game.showAll("d2t   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops)));watcher();}
 				}
 			// Turn over the deck
 			if (game.deck.flip()) {
 				flops++;
 				}
 			if (Global.debug){activeGame.append(game.showAll("s.flip >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops)));}
-			if (Global.watch){System.out.println(game.showAll("s.flip >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops))+"\033[23F");Thread.sleep(1000);}
+			if (Global.watch){System.out.println(game.showAll("s.flip >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops)));watcher();}
 			// Did we win by putting all cards in the foundation?
 			if (game.foundation.winner()) {
  				if (Global.debug) {
@@ -71,10 +82,6 @@ public class Player {
 				break;
 				}
 			}
-		}
-	catch (Exception e) {
-		System.err.println(e);
-		}
 		//-------------------------------------------
 		if ((Global.debug) && (!won)) {
 			activeGame.append(game.showAll("loser >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops)));

--- a/src/org/dacracot/Solitaire.java
+++ b/src/org/dacracot/Solitaire.java
@@ -67,30 +67,51 @@ public class Solitaire {
 			if ((Global.quiet)||(Global.watch)) {
 				Global.debug = false;
 				}
-			if (Global.quiet) {
-				Global.watch = false;
+			if (Global.watch) {
+				Global.quiet = false;
+				Global.random = new Random(1L);
+				Global.tries = 1;
 				}
 			}
 		else{
-			System.out.println("usage: [--one|--three] [--attempts #|--continuous] [--debug|--watch|--quiet] [--seed #]");
+			System.out.println("usage: [--watch | [--one|--three] [--attempts #|--continuous] [--debug|--quiet] [--seed #]]");
 			System.out.println("    --one: Turn only one card each play.");
 			System.out.println("    --three: Turn three cards each play.");
 			System.out.println("    --attempts: Number of games to attempt.");
 			System.out.println("    --continuous: Attempt games until killed.");
 			System.out.println("    --debug: Verbose output about each game.");
-			System.out.println("    --watch: Verbose output about each game played out in the console.");
 			System.out.println("    --quiet: Minimal output about each game.");
 			System.out.println("    --seed: Random seed for repeatable play.");
+			System.out.println("    --watch: Outputs at one second per move, a single winnable game. No other switch is considered.");
 			System.out.println("");
 			Global.random = new Random(); // truly Random for no parameters
 			}
 		System.out.println("");
+		if (Global.watch) {
+			System.out.println("running: turn "+Global.cards+" cards for one winnable game watching play on console");
+			System.out.println("PRESS ENTER TO CONTINUE");
+			try {
+				System.in.read();
+				}
+			catch (Exception e) {
+				System.err.println(e);
+				System.exit(1);
+				}
+			}
+		else {
+			System.out.println(
+				"running: turn "+Global.cards+" cards"+
+				((Global.tries==Integer.MAX_VALUE)?" until killed":" for "+String.format("%,d",Global.tries)+" attempts")+
+				(Global.quiet?" quietly ":" ")+
+				(Global.debug?"with":"without")+" debug "+
+				(seeded?("with "+seed+" seed"):"without a seed")
+				);
+			}
 		System.out.println(
 			"running: turn "+Global.cards+" cards"+
 			((Global.tries==Integer.MAX_VALUE)?" until killed":" for "+String.format("%,d",Global.tries)+" attempts")+
 			(Global.quiet?" quietly ":" ")+
 			(Global.debug?"with":"without")+" debug "+
-			(Global.watch?"with":"without")+" console watch  "+
 			(seeded?("with "+seed+" seed"):"without a seed")
 			);
 		System.out.println("");

--- a/src/org/dacracot/Solitaire.java
+++ b/src/org/dacracot/Solitaire.java
@@ -62,18 +62,23 @@ public class Solitaire {
 				Global.random = new Random(); // truly Random
 				}
 			Global.debug = (params.indexOf("--debug") != -1);
+			Global.watch = (params.indexOf("--watch") != -1);
 			Global.quiet = (params.indexOf("--quiet") != -1);
-			if (Global.quiet) {
+			if ((Global.quiet)||(Global.watch)) {
 				Global.debug = false;
+				}
+			if (Global.quiet) {
+				Global.watch = false;
 				}
 			}
 		else{
-			System.out.println("usage: [--one|--three] [--attempts #|--continuous] [--debug|--quiet] [--seed #]");
+			System.out.println("usage: [--one|--three] [--attempts #|--continuous] [--debug|--watch|--quiet] [--seed #]");
 			System.out.println("    --one: Turn only one card each play.");
 			System.out.println("    --three: Turn three cards each play.");
 			System.out.println("    --attempts: Number of games to attempt.");
 			System.out.println("    --continuous: Attempt games until killed.");
 			System.out.println("    --debug: Verbose output about each game.");
+			System.out.println("    --watch: Verbose output about each game played out in the console.");
 			System.out.println("    --quiet: Minimal output about each game.");
 			System.out.println("    --seed: Random seed for repeatable play.");
 			System.out.println("");

--- a/src/org/dacracot/Solitaire.java
+++ b/src/org/dacracot/Solitaire.java
@@ -69,6 +69,7 @@ public class Solitaire {
 				}
 			if (Global.watch) {
 				Global.quiet = false;
+				Global.cards = 3;
 				Global.random = new Random(1L);
 				Global.tries = 1;
 				}

--- a/src/org/dacracot/Solitaire.java
+++ b/src/org/dacracot/Solitaire.java
@@ -108,13 +108,6 @@ public class Solitaire {
 				(seeded?("with "+seed+" seed"):"without a seed")
 				);
 			}
-		System.out.println(
-			"running: turn "+Global.cards+" cards"+
-			((Global.tries==Integer.MAX_VALUE)?" until killed":" for "+String.format("%,d",Global.tries)+" attempts")+
-			(Global.quiet?" quietly ":" ")+
-			(Global.debug?"with":"without")+" debug "+
-			(seeded?("with "+seed+" seed"):"without a seed")
-			);
 		System.out.println("");
 		//-------------------------------------------
 		while(Global.getTried()<Global.tries){

--- a/src/org/dacracot/Solitaire.java
+++ b/src/org/dacracot/Solitaire.java
@@ -90,6 +90,7 @@ public class Solitaire {
 			((Global.tries==Integer.MAX_VALUE)?" until killed":" for "+String.format("%,d",Global.tries)+" attempts")+
 			(Global.quiet?" quietly ":" ")+
 			(Global.debug?"with":"without")+" debug "+
+			(Global.watch?"with":"without")+" console watch  "+
 			(seeded?("with "+seed+" seed"):"without a seed")
 			);
 		System.out.println("");


### PR DESCRIPTION
watch overrides other switches to run a game played, one second per move, to the console, with a seed from a winnable game

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `--watch` flag that plays a single seeded-winnable game one move per second, printing each state to the console with ANSI screen clears. It introduces a new global flag, a `watcher()` helper for the timed delay, and wires the display calls into every step of the game loop.

- A duplicate unconditional `System.out.println(\"running: …\")` block was left in `Solitaire.java` after the new `if/else` watch-specific block was added, causing two \"running:\" lines to print on every execution and a misleading stats line during watch mode.
- The `--watch` override block does not reset `Global.cards`, so combining `--watch` with `--one` or `--three` silently ignores the documented \"no other switch is considered\" contract.

<h3>Confidence Score: 3/5</h3>

The watch gameplay logic works correctly but a stale print block causes doubled output on every run, including non-watch modes already in production.

The leftover unconditional println block (lines 110–116) causes doubled "running:" output on every invocation. In watch mode the second line contradicts the watch-specific announcement directly above it, making the output confusing and incorrect.

src/org/dacracot/Solitaire.java — duplicate println block and incomplete flag-override logic both sit there.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/org/dacracot/Solitaire.java | Adds --watch flag parsing and setup; introduces a duplicate unconditional "running:" println that causes doubled output in all modes and a misleading message in watch mode. |
| src/org/dacracot/Player.java | Adds watcher() helper (1-second sleep + ANSI screen clear) and injects watch-mode print/delay at each game step; looks correct. |
| src/org/dacracot/Global.java | Adds public static boolean watch = false; — straightforward, no issues. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Main as Solitaire.main()
    participant Global
    participant Player
    participant Watcher as watcher()

    Main->>Global: "parse --watch, Global.watch=true"
    Main->>Global: "override: random=new Random(1L), tries=1, debug=false, quiet=false"
    Main->>Main: print watch banner + PRESS ENTER
    Main->>Main: duplicate print "running:" unconditionally (BUG)
    Main->>Player: new Player(Global.cards)
    Player->>Player: play() init Klondike game
    Player->>Main: print showAll Ready to Play
    Player->>Watcher: watcher() sleep 1s, clear screen
    loop Each game step d2f t2t t2f d2t s.flip
        Player->>Main: println showAll step label
        Player->>Watcher: watcher() sleep 1s, clear screen
    end
    alt Game won
        Player->>Global: Global.win()
    end
    Main->>Main: shutdown hook prints final stats
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/org/dacracot/Solitaire.java`, line 110-116 ([link](https://github.com/dacracot/klondike3-simulator/blob/208642c3f789b3f3ed8f9f4bb2fc4ffdb54d5214/src/org/dacracot/Solitaire.java#L110-L116)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Duplicate "running:" print — original block not removed**

   The PR adds a new `if (Global.watch) { … } else { … }` block (lines 101–109) to print a watch-specific message, but the **original unconditional `System.out.println("running: …")` block** (lines 110–116) was left in place. Every execution now prints two "running:" lines. In watch mode the second print is especially misleading — it reports attempts, debug state, and seed in a way that contradicts the watch announcement just above it.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["watch overrides other switches"](https://github.com/dacracot/klondike3-simulator/commit/208642c3f789b3f3ed8f9f4bb2fc4ffdb54d5214) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36857765)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->