### PR TITLE
Version 1.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 ---
 
 ## Versions
+- 1.10
+  - Play unchanged. Added switch --watch, which plays a single, turn three, winnable game, one second per move, to the console.
 - 1.9
   - Play unchanged. Changed terminology to commonly used, board -> tableau, goal -> foundation, and stack -> deck.
 - 1.8, 1.8.1
@@ -32,7 +34,7 @@
   - Using Apache Ant to build project with default build.xml.
     - Targets are "clean" and "compile.java".  Default runs both.
 - run `java -jar simulator.jar`
-  - usage: `[--one|--three] [--attempts #|--continuous] [--debug|--quiet] [--seed #]`
+  - usage: `usage: [--watch | [--one|--three] [--attempts #|--continuous] [--debug|--quiet] [--seed #]]`
     - `--one`: Turn only one card each play.
     - `--three`: Turn three cards each play.
     - `--attempts`: Number of games to attempt.
@@ -40,6 +42,7 @@
     - `--debug`: Verbose output about each game.
     - `--quiet`: Minimal output about each game.
     - `--seed`: Random seed for repeatable play.
+    - `--watch`: Outputs at one second per move, a single winnable game. No other switch is considered.
   - For example: `java -jar simulator.jar --three --attempts 10 --seed 1111 > debug.out 2> debug.err`
     - Run java with the simulator jar.
     - Turn three cards for each turn.
@@ -47,6 +50,11 @@
     - Shuffle the deck starting with the seed 1111.
     - Write standard output to debug.out.
     - Write standard error to debug.err.
+  - Another example: `java -jar simulator.jar --watch`
+    - Run java with the simulator jar.
+    - Turn three cards for each turn.
+    - Play a single winnable game.
+    - Display each move in the console.
 - run `java -jar simulator.jar --quiet --three --attempts 100000000 --seed 1111 > myWinningPercentage.txt` to determine your success rate verses the current record.
 	- Compare your results with winningPercentage.txt and PR your file if better.
 

--- a/src/org/dacracot/Global.java
+++ b/src/org/dacracot/Global.java
@@ -13,6 +13,7 @@ public class Global {
 	public static int tries = 10;
 	public static Random random = null;
 	public static boolean debug = false;
+	public static boolean watch = false;
 	public static boolean quiet = false;
 	//-----------------------------------------------
 	public static double valueSum = 0;

--- a/src/org/dacracot/Player.java
+++ b/src/org/dacracot/Player.java
@@ -20,10 +20,12 @@ public class Player {
 		FromTableau fromTableau = new FromTableau(game);
 		FromFoundation fromFoundation = new FromFoundation(game);
 		if (Global.debug){activeGame.append(game.showAll("Ready to Play"));}
+		if (Global.watch){System.out.println(game.showAll("Ready to Play"));}
 		//-------------------------------------------
 		boolean won = false;
 		int loops = 0;
 		int flops = 0;
+	try {
 		// Play until there are no moves for three loops.
 		while(flops < 3) {
 			// Play only one (or none) from deck to foundation
@@ -32,11 +34,11 @@ public class Player {
 				flops = 0;
 				}
 			if (Global.debug){activeGame.append(game.showAll("d2f   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops)));}
-			if (Global.watch){game.showAll("d2f   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops));System.out.print("\033[23F");}
+			if (Global.watch){System.out.println(game.showAll("d2f   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops))+"\033[23F");Thread.sleep(1000);}
 			// Play tableau to tableau until no more moves available
 			while(fromTableau.toTableau()) {
 				if (Global.debug){activeGame.append(game.showAll("t2t   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops)));}
-				if (Global.watch){game.showAll("t2t   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops));System.out.print("\033[23F");}
+				if (Global.watch){System.out.println(game.showAll("t2t   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops))+"\033[23F");Thread.sleep(1000);}
 				}
 			// Play only one (or none) from tableau to foundation
 			if (fromTableau.toFoundation()) {
@@ -44,18 +46,18 @@ public class Player {
 				flops = 0;
 				}
 			if (Global.debug){activeGame.append(game.showAll("t2f   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops)));}
-			if (Global.watch){game.showAll("t2f   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops));System.out.print("\033[23F");}
+			if (Global.watch){System.out.println(game.showAll("t2f   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops))+"\033[23F");Thread.sleep(1000);}
 			// Play deck to tableau until no more moves available
 			while(fromDeck.toTableau()) {
 				if (Global.debug){activeGame.append(game.showAll("d2t   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops)));}
-				if (Global.watch){game.showAll("d2t   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops));System.out.print("\033[23F");}
+				if (Global.watch){System.out.println(game.showAll("d2t   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops))+"\033[23F");Thread.sleep(1000);}
 				}
 			// Turn over the deck
 			if (game.deck.flip()) {
 				flops++;
 				}
 			if (Global.debug){activeGame.append(game.showAll("s.flip >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops)));}
-			if (Global.watch){game.showAll("s.flip >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops));System.out.print("\033[23F");}
+			if (Global.watch){System.out.println(game.showAll("s.flip >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops))+"\033[23F");Thread.sleep(1000);}
 			// Did we win by putting all cards in the foundation?
 			if (game.foundation.winner()) {
  				if (Global.debug) {
@@ -69,6 +71,10 @@ public class Player {
 				break;
 				}
 			}
+		}
+	catch (Exception e) {
+		System.err.println(e);
+		}
 		//-------------------------------------------
 		if ((Global.debug) && (!won)) {
 			activeGame.append(game.showAll("loser >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops)));

--- a/src/org/dacracot/Player.java
+++ b/src/org/dacracot/Player.java
@@ -32,9 +32,11 @@ public class Player {
 				flops = 0;
 				}
 			if (Global.debug){activeGame.append(game.showAll("d2f   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops)));}
+			if (Global.watch){game.showAll("d2f   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops));System.out.print("\033[23F");}
 			// Play tableau to tableau until no more moves available
 			while(fromTableau.toTableau()) {
 				if (Global.debug){activeGame.append(game.showAll("t2t   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops)));}
+				if (Global.watch){game.showAll("t2t   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops));System.out.print("\033[23F");}
 				}
 			// Play only one (or none) from tableau to foundation
 			if (fromTableau.toFoundation()) {
@@ -42,15 +44,18 @@ public class Player {
 				flops = 0;
 				}
 			if (Global.debug){activeGame.append(game.showAll("t2f   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops)));}
+			if (Global.watch){game.showAll("t2f   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops));System.out.print("\033[23F");}
 			// Play deck to tableau until no more moves available
 			while(fromDeck.toTableau()) {
 				if (Global.debug){activeGame.append(game.showAll("d2t   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops)));}
+				if (Global.watch){game.showAll("d2t   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops));System.out.print("\033[23F");}
 				}
 			// Turn over the deck
 			if (game.deck.flip()) {
 				flops++;
 				}
 			if (Global.debug){activeGame.append(game.showAll("s.flip >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops)));}
+			if (Global.watch){game.showAll("s.flip >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops));System.out.print("\033[23F");}
 			// Did we win by putting all cards in the foundation?
 			if (game.foundation.winner()) {
  				if (Global.debug) {

--- a/src/org/dacracot/Player.java
+++ b/src/org/dacracot/Player.java
@@ -13,6 +13,18 @@ public class Player {
 		this.cards = cards;
 		}
 	//-----------------------------------------------
+	private void watcher() {
+		try {
+			Thread.sleep(1000); // wait 1 seconds
+			System.out.print("\033[H\033[2J"); // clear screen
+			System.out.flush();
+			}
+		catch (Exception e) {
+			System.err.println(e);
+			System.exit(1);
+			}
+		}
+	//-----------------------------------------------
 	public void play() {
 		Global.play();
 		Klondike game = new Klondike(cards);
@@ -20,12 +32,11 @@ public class Player {
 		FromTableau fromTableau = new FromTableau(game);
 		FromFoundation fromFoundation = new FromFoundation(game);
 		if (Global.debug){activeGame.append(game.showAll("Ready to Play"));}
-		if (Global.watch){System.out.println(game.showAll("Ready to Play"));}
+		if (Global.watch){System.out.print("\033[H\033[2J");System.out.flush();System.out.println(game.showAll("Ready to Play"));watcher();}
 		//-------------------------------------------
 		boolean won = false;
 		int loops = 0;
 		int flops = 0;
-	try {
 		// Play until there are no moves for three loops.
 		while(flops < 3) {
 			// Play only one (or none) from deck to foundation
@@ -34,11 +45,11 @@ public class Player {
 				flops = 0;
 				}
 			if (Global.debug){activeGame.append(game.showAll("d2f   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops)));}
-			if (Global.watch){System.out.println(game.showAll("d2f   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops))+"\033[23F");Thread.sleep(1000);}
+			if (Global.watch){System.out.println(game.showAll("d2f   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops)));watcher();}
 			// Play tableau to tableau until no more moves available
 			while(fromTableau.toTableau()) {
 				if (Global.debug){activeGame.append(game.showAll("t2t   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops)));}
-				if (Global.watch){System.out.println(game.showAll("t2t   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops))+"\033[23F");Thread.sleep(1000);}
+				if (Global.watch){System.out.println(game.showAll("t2t   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops)));watcher();}
 				}
 			// Play only one (or none) from tableau to foundation
 			if (fromTableau.toFoundation()) {
@@ -46,18 +57,18 @@ public class Player {
 				flops = 0;
 				}
 			if (Global.debug){activeGame.append(game.showAll("t2f   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops)));}
-			if (Global.watch){System.out.println(game.showAll("t2f   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops))+"\033[23F");Thread.sleep(1000);}
+			if (Global.watch){System.out.println(game.showAll("t2f   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops)));watcher();}
 			// Play deck to tableau until no more moves available
 			while(fromDeck.toTableau()) {
 				if (Global.debug){activeGame.append(game.showAll("d2t   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops)));}
-				if (Global.watch){System.out.println(game.showAll("d2t   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops))+"\033[23F");Thread.sleep(1000);}
+				if (Global.watch){System.out.println(game.showAll("d2t   >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops)));watcher();}
 				}
 			// Turn over the deck
 			if (game.deck.flip()) {
 				flops++;
 				}
 			if (Global.debug){activeGame.append(game.showAll("s.flip >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops)));}
-			if (Global.watch){System.out.println(game.showAll("s.flip >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops))+"\033[23F");Thread.sleep(1000);}
+			if (Global.watch){System.out.println(game.showAll("s.flip >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops)));watcher();}
 			// Did we win by putting all cards in the foundation?
 			if (game.foundation.winner()) {
  				if (Global.debug) {
@@ -71,10 +82,6 @@ public class Player {
 				break;
 				}
 			}
-		}
-	catch (Exception e) {
-		System.err.println(e);
-		}
 		//-------------------------------------------
 		if ((Global.debug) && (!won)) {
 			activeGame.append(game.showAll("loser >> loops: "+Integer.toString(loops++)+" | flops:"+Integer.toString(flops)));

--- a/src/org/dacracot/Solitaire.java
+++ b/src/org/dacracot/Solitaire.java
@@ -67,30 +67,51 @@ public class Solitaire {
 			if ((Global.quiet)||(Global.watch)) {
 				Global.debug = false;
 				}
-			if (Global.quiet) {
-				Global.watch = false;
+			if (Global.watch) {
+				Global.quiet = false;
+				Global.random = new Random(1L);
+				Global.tries = 1;
 				}
 			}
 		else{
-			System.out.println("usage: [--one|--three] [--attempts #|--continuous] [--debug|--watch|--quiet] [--seed #]");
+			System.out.println("usage: [--watch | [--one|--three] [--attempts #|--continuous] [--debug|--quiet] [--seed #]]");
 			System.out.println("    --one: Turn only one card each play.");
 			System.out.println("    --three: Turn three cards each play.");
 			System.out.println("    --attempts: Number of games to attempt.");
 			System.out.println("    --continuous: Attempt games until killed.");
 			System.out.println("    --debug: Verbose output about each game.");
-			System.out.println("    --watch: Verbose output about each game played out in the console.");
 			System.out.println("    --quiet: Minimal output about each game.");
 			System.out.println("    --seed: Random seed for repeatable play.");
+			System.out.println("    --watch: Outputs at one second per move, a single winnable game. No other switch is considered.");
 			System.out.println("");
 			Global.random = new Random(); // truly Random for no parameters
 			}
 		System.out.println("");
+		if (Global.watch) {
+			System.out.println("running: turn "+Global.cards+" cards for one winnable game watching play on console");
+			System.out.println("PRESS ENTER TO CONTINUE");
+			try {
+				System.in.read();
+				}
+			catch (Exception e) {
+				System.err.println(e);
+				System.exit(1);
+				}
+			}
+		else {
+			System.out.println(
+				"running: turn "+Global.cards+" cards"+
+				((Global.tries==Integer.MAX_VALUE)?" until killed":" for "+String.format("%,d",Global.tries)+" attempts")+
+				(Global.quiet?" quietly ":" ")+
+				(Global.debug?"with":"without")+" debug "+
+				(seeded?("with "+seed+" seed"):"without a seed")
+				);
+			}
 		System.out.println(
 			"running: turn "+Global.cards+" cards"+
 			((Global.tries==Integer.MAX_VALUE)?" until killed":" for "+String.format("%,d",Global.tries)+" attempts")+
 			(Global.quiet?" quietly ":" ")+
 			(Global.debug?"with":"without")+" debug "+
-			(Global.watch?"with":"without")+" console watch  "+
 			(seeded?("with "+seed+" seed"):"without a seed")
 			);
 		System.out.println("");

--- a/src/org/dacracot/Solitaire.java
+++ b/src/org/dacracot/Solitaire.java
@@ -62,18 +62,23 @@ public class Solitaire {
 				Global.random = new Random(); // truly Random
 				}
 			Global.debug = (params.indexOf("--debug") != -1);
+			Global.watch = (params.indexOf("--watch") != -1);
 			Global.quiet = (params.indexOf("--quiet") != -1);
-			if (Global.quiet) {
+			if ((Global.quiet)||(Global.watch)) {
 				Global.debug = false;
+				}
+			if (Global.quiet) {
+				Global.watch = false;
 				}
 			}
 		else{
-			System.out.println("usage: [--one|--three] [--attempts #|--continuous] [--debug|--quiet] [--seed #]");
+			System.out.println("usage: [--one|--three] [--attempts #|--continuous] [--debug|--watch|--quiet] [--seed #]");
 			System.out.println("    --one: Turn only one card each play.");
 			System.out.println("    --three: Turn three cards each play.");
 			System.out.println("    --attempts: Number of games to attempt.");
 			System.out.println("    --continuous: Attempt games until killed.");
 			System.out.println("    --debug: Verbose output about each game.");
+			System.out.println("    --watch: Verbose output about each game played out in the console.");
 			System.out.println("    --quiet: Minimal output about each game.");
 			System.out.println("    --seed: Random seed for repeatable play.");
 			System.out.println("");

--- a/src/org/dacracot/Solitaire.java
+++ b/src/org/dacracot/Solitaire.java
@@ -69,6 +69,7 @@ public class Solitaire {
 				}
 			if (Global.watch) {
 				Global.quiet = false;
+				Global.cards = 3;
 				Global.random = new Random(1L);
 				Global.tries = 1;
 				}

--- a/src/org/dacracot/Solitaire.java
+++ b/src/org/dacracot/Solitaire.java
@@ -108,13 +108,6 @@ public class Solitaire {
 				(seeded?("with "+seed+" seed"):"without a seed")
 				);
 			}
-		System.out.println(
-			"running: turn "+Global.cards+" cards"+
-			((Global.tries==Integer.MAX_VALUE)?" until killed":" for "+String.format("%,d",Global.tries)+" attempts")+
-			(Global.quiet?" quietly ":" ")+
-			(Global.debug?"with":"without")+" debug "+
-			(seeded?("with "+seed+" seed"):"without a seed")
-			);
 		System.out.println("");
 		//-------------------------------------------
 		while(Global.getTried()<Global.tries){

--- a/src/org/dacracot/Solitaire.java
+++ b/src/org/dacracot/Solitaire.java
@@ -90,6 +90,7 @@ public class Solitaire {
 			((Global.tries==Integer.MAX_VALUE)?" until killed":" for "+String.format("%,d",Global.tries)+" attempts")+
 			(Global.quiet?" quietly ":" ")+
 			(Global.debug?"with":"without")+" debug "+
+			(Global.watch?"with":"without")+" console watch  "+
 			(seeded?("with "+seed+" seed"):"without a seed")
 			);
 		System.out.println("");


### PR DESCRIPTION
New watch switch.
- Run java with the simulator jar.
- Turn three cards for each turn.
- Play a single winnable game.
- Display each move in the console.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a `--watch` mode that plays a single, pre-seeded winnable Klondike game in turn-3 mode at one second per move, printing each board state to the console with ANSI screen clearing between moves.

- `Global.java` adds a `watch` boolean; `Solitaire.java` parses `--watch`, forces `cards=3`, `tries=1`, and a fixed seed (`1L`), overriding any other flags.
- `Player.java` adds a `watcher()` helper (sleep 1 s + clear screen) and injects watch-mode print/clear calls alongside the existing debug branches throughout the game loop.
- README and usage strings are updated accordingly.

<h3>Confidence Score: 3/5</h3>

The watch mode works for the happy path but silently clears the winning board state before the user can see it, leaving the feature feeling incomplete.

The final board of a winning game is erased by the last watcher() clear just before the win-check, so the user never sees the completed game — the main point of the watch feature. The loops counter is also incremented independently in both debug and watch branches, meaning step numbers in watch output differ from what debug mode would show for the same game.

src/org/dacracot/Player.java — the win-detection block and the watch-mode print/watcher call ordering around it deserve a second look.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/org/dacracot/Player.java | Adds watcher() and watch-mode logging; loops counter diverges from debug-mode count, and the winning board is cleared before the win announcement fires. |
| src/org/dacracot/Solitaire.java | Parses --watch and overrides game settings; seed/watch flag ordering is fragile but currently correct. |
| src/org/dacracot/Global.java | Adds static watch boolean flag; straightforward one-line addition. |
| README.md | Documents --watch flag and new example invocation; minor documentation update. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant U as User (terminal)
    participant S as Solitaire.main()
    participant P as Player.play()
    participant W as watcher()

    U->>S: java -jar simulator.jar --watch
    S->>S: "parse flags: cards=3, tries=1, seed=1L"
    S->>U: print running message
    S->>U: PRESS ENTER TO CONTINUE
    U->>S: (Enter key)
    S->>P: new Player(3).play()
    P->>U: clear screen + print Ready to Play board
    P->>W: watcher()
    W->>W: Thread.sleep(1000)
    W->>U: clear screen (ANSI escape)
    loop "game loop (flops < 3)"
        P->>U: print move state
        P->>W: watcher()
        W->>W: Thread.sleep(1000)
        W->>U: clear screen
    end
    P->>S: return (win or lose)
    S->>U: print Game 1 of 1
    Note over S,U: JVM exit triggers shutdown hook
    S->>U: print success statistics
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src/org/dacracot/Player.java`, line 72-83 ([link](https://github.com/dacracot/klondike3-simulator/blob/527ebfb503e07ee8fd3b0fc2c6154339550bfb1d/src/org/dacracot/Player.java#L72-L83)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **No winner announcement shown in watch mode**

   When `--watch` is active and the game is won, the code sets `won = true` and calls `Global.win()`, but the winner banner is guarded by `Global.debug`, which is forced `false` by `--watch`. The screen also gets cleared by the last `watcher()` call just before the win check, so the final winning board state is erased and the console ends silently. A watch-specific win message (or at minimum skipping the final `watcher()` clear on win) would let the user see the completed game.


2. `src/org/dacracot/Solitaire.java`, line 61-75 ([link](https://github.com/dacracot/klondike3-simulator/blob/527ebfb503e07ee8fd3b0fc2c6154339550bfb1d/src/org/dacracot/Solitaire.java#L61-L75)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`--seed` / `--watch` flag ordering sensitivity**

   The `else` branch of the `--seed` check unconditionally sets `Global.random = new Random()`. The `--watch` block then overwrites it with `new Random(1L)`. This works today, but correctness depends on `--watch` being processed after the seed block — a fragile ordering dependency. Consider checking `--watch` first and returning early, or restructuring so the `else` does not run when `--watch` is present.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["never enough README"](https://github.com/dacracot/klondike3-simulator/commit/527ebfb503e07ee8fd3b0fc2c6154339550bfb1d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36861343)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->