### PR TITLE
Version 1.12.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Current record of **19.7%** is detailed in winningPercentage.txt.gz.
 - d2f: from Deck to Foundation
 
 ## Example Output
-- Output from a debug only parameter run:
+- Output from `java -jar simulator.jar --watch`:
 
 ![watch example](example.gif)
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Current record of **19.7%** is detailed in winningPercentage.txt.gz.
 ---
 
 ## Versions
-- 1.12
+- 1.12, 1.12.1
   - Play altered to rescue a loss by returning foundation cards to the tableau.  Winning percentage increased from 17.81353% to 19.70935%.
 - 1.11
   - Play altered to properly play until the end. Winnable games were left behind.  Winning percentage increased from 11.74316% to 17.81353%.

--- a/gamePlay.md
+++ b/gamePlay.md
@@ -1,0 +1,225 @@
+## Game play...
+
+Description of the game play strategy currently in use.
+
+---
+
+# Deep Call Graph Analysis
+
+The solver's execution graph is much more interesting than the high-level diagram suggests. The actual call hierarchy looks roughly like this:
+
+```mermaid
+flowchart TD
+
+    A[Solitaire.main] --> B[Parse CLI Arguments]
+    B --> C[Initialize Global State]
+    C --> D[Game Loop]
+
+    D --> E[Player.play]
+
+    E --> F[new Klondike]
+    E --> G[playNormal]
+
+    G --> H[FromDeck.toFoundation]
+    G --> I[FromTableau.toTableau]
+    G --> J[FromTableau.toFoundation]
+    G --> K[FromDeck.toTableau]
+    G --> L[Deck.flip]
+
+    H --> H1[Deck.getUpCard]
+    H --> H2[Foundation.playCard]
+    H2 --> H3[Deck.removeUpCard]
+
+    I --> I1[Tableau.getUpCardsFromBottom]
+    I --> I2[Tableau.getUpCardsFromTop]
+    I --> I3[Sort longest columns first]
+    I3 --> I4[playKingFromTableau]
+    I3 --> I5[playCard bottom/top]
+
+    J --> J1[Tableau.getUpCardsFromBottom]
+    J --> J2[Sort shortest columns first]
+    J2 --> J3[Foundation.playCard]
+    J3 --> J4[Tableau.removeCard]
+
+    K --> K1[Deck.getUpCard]
+    K1 --> K2[playKingFromDeck]
+    K1 --> K3[Tableau.playCard]
+    K2 --> K4[Deck.removeUpCard]
+    K3 --> K4
+
+    G --> M{Foundation.winner}
+
+    M -->|No| N[playRescue]
+    M -->|Yes| O[Global.win]
+
+    N --> P[FromFoundation.toTableau]
+
+    P --> P1[Foundation.getUpCardsFromBottom]
+    P --> P2[Tableau.getUpCardsFromBottom]
+    P --> P3[Sort longest foundation first]
+    P3 --> P4[Tableau.returnCard]
+    P4 --> P5[Foundation.removeCard]
+
+    N --> Q[FromTableau.toTableau]
+    N --> R[FromDeck.toTableau]
+
+    N --> S{Rescue moved cards}
+    S -->|Yes| G
+    S -->|No| T[Loss]
+
+    O --> U[Statistics]
+    T --> U
+```
+
+## Actual Solver Decision Tree
+
+The heart of the application is `Player.playNormal()`.
+
+Every iteration executes in this exact order:
+
+```text
+1. Deck      -> Foundation
+2. Tableau   -> Tableau (repeat until exhausted)
+3. Tableau   -> Foundation
+4. Deck      -> Tableau (repeat until exhausted)
+5. Flip Stock
+```
+
+This is not merely a move list—it defines the entire search strategy.
+
+---
+
+## Tableau-to-Tableau Heuristic
+
+Your strongest heuristic is here:
+
+```java
+Collections.sort(topUpCards, CardColumnLengthDescending);
+```
+
+This means:
+
+```text
+Candidate Moves
+    ↓
+Choose source column
+    ↓
+Longest column first
+    ↓
+Attempt move
+```
+
+Conceptually:
+
+```text
+Move Available?
+│
+├─ No
+│   └─ Continue Search
+│
+└─ Yes
+    │
+    ├─ Exposes hidden card?
+    │     └─ Highest Priority
+    │
+    └─ Otherwise
+          First legal move
+```
+
+Hidden-card exposure is currently the dominant factor in solver success.
+
+---
+
+## Rescue Phase Graph
+
+The new rescue phase behaves like a second search engine.
+
+```text
+Normal Play Fails
+        │
+        ▼
+Return Foundation Card
+        │
+        ▼
+Tableau → Tableau Exhaustively
+        │
+        ▼
+Deck → Tableau Exhaustively
+        │
+        ▼
+More Foundation Cards Available?
+        │
+ ┌──────┴──────┐
+ │             │
+Yes           No
+ │             │
+ ▼             ▼
+Repeat     Resume Normal Play
+```
+
+Limited backtracking without undoing the whole game state.
+
+---
+
+## Foundation Return Logic
+
+`FromFoundation.toTableau()`
+
+```text
+Foundation Cards
+       │
+       ▼
+Sort Longest Foundation First
+       │
+       ▼
+Find Tableau Target
+       │
+       ▼
+Legal Return?
+       │
+ ┌─────┴─────┐
+ │           │
+No          Yes
+ │           │
+ ▼           ▼
+Next Card  Remove From Foundation
+                │
+                ▼
+           Return Success
+```
+
+Prioritizes dismantling the most advanced foundation pile first.
+
+---
+
+## Most Important Observation
+
+The solver is not a pure greedy solver, instead it effectively implements:
+
+```text
+Greedy Search
+      +
+Limited Backtracking
+      +
+Hidden-Card Exposure Bias
+```
+
+The rescue phase converts the algorithm from:
+
+```text
+Single-path search
+```
+
+into:
+
+```text
+Search
+    ↓
+Dead End
+    ↓
+Partial Rollback
+    ↓
+Continue Search
+```
+
+which accounts for the larger winning percentage than common heuristic tweaks.


### PR DESCRIPTION
Edited README and added the game play description.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds version 1.12.1 to the README version list alongside 1.12 (matching the existing multi-version entry pattern), updates the example output caption to reference the actual `--watch` command, and introduces a new `gamePlay.md` document describing the solver's call graph, decision ordering, heuristics, and rescue phase logic.

- **README.md**: Version entry updated from `1.12` to `1.12, 1.12.1` (consistent with prior groupings like `1.10, 1.10.1`) and the example output caption now shows the actual command instead of vague "debug only parameter" wording.
- **gamePlay.md**: New documentation file with Mermaid and ASCII diagrams covering the full solver call graph, move-ordering strategy, tableau heuristics, and rescue phase backtracking logic. Has an inverted heading hierarchy (H2 opener, H1 sections) that should be corrected.

<h3>Confidence Score: 4/5</h3>

Documentation-only changes with no code impact; safe to merge.

Both changes are purely documentation. The README update is consistent with existing version-grouping conventions in the file. The new gamePlay.md is well-structured and accurate but has an inverted heading hierarchy (H2 opening, H1 sections) that should be corrected before the file is published or linked from other docs.

gamePlay.md — the heading hierarchy starts at H2 and then uses H1 for all subsequent sections, which should be flipped.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Adds 1.12.1 to the existing 1.12 version entry (consistent with prior multi-version entries like 1.10/1.10.1) and improves the example output caption to show the actual command instead of vague "debug only parameter" language. |
| gamePlay.md | New documentation file describing the solver's call graph, decision tree, and heuristics with Mermaid/text diagrams. The opening heading uses H2 while all subsequent section headings use H1, creating an inverted hierarchy. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Player.playNormal] --> B[Deck → Foundation]
    B --> C[Tableau → Tableau\nrepeat until exhausted]
    C --> D[Tableau → Foundation]
    D --> E[Deck → Tableau\nrepeat until exhausted]
    E --> F[Flip Stock]
    F --> G{Foundation.winner?}
    G -->|Yes| H[Win + Statistics]
    G -->|No| I[playRescue]
    I --> J[Foundation → Tableau\nlongest foundation first]
    J --> K[Tableau → Tableau]
    K --> L[Deck → Tableau]
    L --> M{Cards moved?}
    M -->|Yes| A
    M -->|No| N[Loss + Statistics]
```

<sub>Reviews (1): Last reviewed commit: ["never enough README"](https://github.com/dacracot/klondike3-simulator/commit/2a9e73560a6237ef4752101ee02b024f960e5852) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37526386)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->